### PR TITLE
Add license compliance workflow

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -2,12 +2,13 @@ name: License Compliance Check
 
 on:
   pull_request:
-    paths:
-      - 'go.mod'
-      - 'go.sum'
+    branches: [main]
   push:
     branches: [main]
   workflow_dispatch:
+
+env:
+  GO_LICENSES_VERSION: v1.6.0
 
 jobs:
   license-check:
@@ -22,7 +23,10 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
+        run: |
+          mkdir -p "${RUNNER_TEMP}/go-bin"
+          echo "${RUNNER_TEMP}/go-bin" >> "${GITHUB_PATH}"
+          GOBIN="${RUNNER_TEMP}/go-bin" go install github.com/google/go-licenses@${GO_LICENSES_VERSION}
 
       - name: Check licenses
         run: |

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,43 @@
+name: License Compliance Check
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Check licenses
+        run: |
+          echo "Checking dependency licenses for compliance..."
+          go-licenses check --disallowed_types=forbidden,reciprocal,restricted,unknown ./...
+
+      - name: Generate license report
+        if: always()
+        run: |
+          echo "Generating license report..."
+          go-licenses csv ./... > licenses.csv 2>&1 || true
+
+      - name: Upload license report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.0
+        with:
+          name: license-report
+          path: licenses.csv

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -2,7 +2,9 @@ name: License Compliance Check
 
 on:
   pull_request:
-    branches: [main]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add a dedicated License Compliance Check workflow ported from gh-aw
- Run license checks when Go module files change, on pushes to main, and manually
- Upload a generated license report artifact for review

## Validation
- Ran `make license-check` successfully
- Confirmed no VS Code-reported file errors