### PR TITLE
Set repository context for release promotion

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release-promote
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Verify prerelease exists
         id: verify


### PR DESCRIPTION
## Summary
- set GH_REPO at the promote workflow job level
- allow gh release commands to run without a checkout/.git directory

## Validation
- workflow YAML checked by VS Code diagnostics
- not run: workflow behavior requires dispatching Promote Release