### PR TITLE
Use latest detector image for container smoke workflows

### DIFF
--- a/.github/workflows/smoke-claude-container.lock.yml
+++ b/.github/workflows/smoke-claude-container.lock.yml
@@ -1227,12 +1227,12 @@ jobs:
       - name: Pull threat detection container
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         env:
-          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:v0.0.2' }}
+          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:latest' }}
         run: docker pull "$THREAT_DETECTION_IMAGE"
       - name: Extract threat detection binary from container
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         env:
-          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:v0.0.2' }}
+          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:latest' }}
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/threat-detect-bin"
           container_id="$(docker create "$THREAT_DETECTION_IMAGE")"

--- a/.github/workflows/smoke-codex-container.lock.yml
+++ b/.github/workflows/smoke-codex-container.lock.yml
@@ -1286,12 +1286,12 @@ jobs:
       - name: Pull threat detection container
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         env:
-          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:v0.0.2' }}
+          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:latest' }}
         run: docker pull "$THREAT_DETECTION_IMAGE"
       - name: Extract threat detection binary from container
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         env:
-          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:v0.0.2' }}
+          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:latest' }}
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/threat-detect-bin"
           container_id="$(docker create "$THREAT_DETECTION_IMAGE")"

--- a/.github/workflows/smoke-copilot-container.lock.yml
+++ b/.github/workflows/smoke-copilot-container.lock.yml
@@ -1181,12 +1181,12 @@ jobs:
       - name: Pull threat detection container
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         env:
-          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:v0.0.2' }}
+          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:latest' }}
         run: docker pull "$THREAT_DETECTION_IMAGE"
       - name: Extract threat detection binary from container
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         env:
-          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:v0.0.2' }}
+          THREAT_DETECTION_IMAGE: ${{ vars.GH_AW_THREAT_DETECTION_IMAGE || 'ghcr.io/github/gh-aw-threat-detection:latest' }}
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/threat-detect-bin"
           container_id="$(docker create "$THREAT_DETECTION_IMAGE")"

--- a/scripts/create-threat-detection-sibling-workflows.py
+++ b/scripts/create-threat-detection-sibling-workflows.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
-DEFAULT_IMAGE = "ghcr.io/github/gh-aw-threat-detection:v0.0.2"
+DEFAULT_IMAGE = "ghcr.io/github/gh-aw-threat-detection:latest"
 ENGINES = {
     "smoke-copilot.lock.yml": ("copilot", "Smoke Copilot Containerized"),
     "smoke-claude.lock.yml": ("claude", "Smoke Claude Containerized"),


### PR DESCRIPTION
## Summary

- Change the generated container smoke workflow default detector image from `v0.0.2` to `latest`.
- Regenerate the Copilot, Claude, and Codex container smoke lock files.

## Why

The `v0.0.2` container predates the Claude CLI `--verbose` fix, so the containerized Claude smoke workflow fails with:

```text
When using --print, --output-format=stream-json requires --verbose
```

`latest` currently resolves to the same manifest digest as `v0.0.3`, which contains the fix.

## Validation

- `scripts/create-threat-detection-sibling-workflows.py --check`
- Verified `ghcr.io/github/gh-aw-threat-detection:latest` and `ghcr.io/github/gh-aw-threat-detection:v0.0.3` both resolve to `sha256:d82065ea8a723ba4e54822d94933783d9c70f897f55a115869169f2699299bb1`