### PR TITLE
Fix container smoke detection fallback

### DIFF
--- a/.github/workflows/smoke-claude-container.lock.yml
+++ b/.github/workflows/smoke-claude-container.lock.yml
@@ -1247,7 +1247,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_CLAUDE || '' }}
-          THREAT_DETECTION_REFLECT_URL: http://127.0.0.1:8080/reflect
+          THREAT_DETECTION_REFLECT_URL: http://host.docker.internal:8080/reflect
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Claude engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |

--- a/.github/workflows/smoke-codex-container.lock.yml
+++ b/.github/workflows/smoke-codex-container.lock.yml
@@ -1306,7 +1306,7 @@ jobs:
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_CODEX || '' }}
-          THREAT_DETECTION_REFLECT_URL: http://127.0.0.1:8080/reflect
+          THREAT_DETECTION_REFLECT_URL: http://host.docker.internal:8080/reflect
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Codex engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |

--- a/.github/workflows/smoke-copilot-container.lock.yml
+++ b/.github/workflows/smoke-copilot-container.lock.yml
@@ -1201,7 +1201,7 @@ jobs:
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
-          THREAT_DETECTION_REFLECT_URL: http://127.0.0.1:8080/reflect
+          THREAT_DETECTION_REFLECT_URL: http://host.docker.internal:8080/reflect
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Copilot engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -67,7 +67,7 @@ type codexEngine struct {
 }
 
 func (e *codexEngine) Analyze(ctx context.Context, prompt string) (string, error) {
-	return runCLIEnv(ctx, "codex", codexArgs(e.model, prompt), "", nil)
+	return runCLIEnv(ctx, "codex", codexArgs(e.model, ""), prompt, nil)
 }
 
 func copilotArgs(promptPath string) []string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -67,9 +67,7 @@ type codexEngine struct {
 }
 
 func (e *codexEngine) Analyze(ctx context.Context, prompt string) (string, error) {
-	return runCLIWithPromptFile(ctx, "codex", prompt, func(promptPath string) []string {
-		return codexArgs(e.model, promptPath)
-	}, nil)
+	return runCLIEnv(ctx, "codex", codexArgs(e.model, prompt), "", nil)
 }
 
 func copilotArgs(promptPath string) []string {
@@ -101,14 +99,15 @@ func claudeArgs(model string) []string {
 	return append(args, "-")
 }
 
-func codexArgs(model, promptPath string) []string {
+func codexArgs(model, prompt string) []string {
 	args := []string{
 		"exec",
 		"-c", "web_search=disabled",
 		"-c", "fetch=disabled",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--skip-git-repo-check",
-		"--prompt-file", promptPath,
+		"--",
+		prompt,
 	}
 	if model != "" {
 		args = append([]string{"-c", "model=" + model}, args...)

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -95,7 +95,7 @@ func TestEngineCommandArgs(t *testing.T) {
 	})
 
 	t.Run("codex", func(t *testing.T) {
-		got := codexArgs("gpt-5-codex", "/tmp/prompt.txt")
+		got := codexArgs("gpt-5-codex", "detect threats")
 		want := []string{
 			"-c", "model=gpt-5-codex",
 			"exec",
@@ -103,7 +103,8 @@ func TestEngineCommandArgs(t *testing.T) {
 			"-c", "fetch=disabled",
 			"--dangerously-bypass-approvals-and-sandbox",
 			"--skip-git-repo-check",
-			"--prompt-file", "/tmp/prompt.txt",
+			"--",
+			"detect threats",
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("codexArgs() = %#v, want %#v", got, want)
@@ -111,14 +112,15 @@ func TestEngineCommandArgs(t *testing.T) {
 	})
 
 	t.Run("codex default model", func(t *testing.T) {
-		got := codexArgs("", "/tmp/prompt.txt")
+		got := codexArgs("", "detect threats")
 		want := []string{
 			"exec",
 			"-c", "web_search=disabled",
 			"-c", "fetch=disabled",
 			"--dangerously-bypass-approvals-and-sandbox",
 			"--skip-git-repo-check",
-			"--prompt-file", "/tmp/prompt.txt",
+			"--",
+			"detect threats",
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("codexArgs() = %#v, want %#v", got, want)

--- a/scripts/create-threat-detection-sibling-workflows.py
+++ b/scripts/create-threat-detection-sibling-workflows.py
@@ -119,7 +119,7 @@ def replacement_steps(engine: str, workflow_description: str, awf_config_line: s
   env:
 {indent(engine_env(engine), 4)}
     THREAT_DETECTION_MODEL: ${{{{ vars.GH_AW_MODEL_DETECTION_{engine.upper()} || '' }}}}
-    THREAT_DETECTION_REFLECT_URL: http://127.0.0.1:8080/reflect
+    THREAT_DETECTION_REFLECT_URL: http://host.docker.internal:8080/reflect
     WORKFLOW_DESCRIPTION: {workflow_description}
     WORKFLOW_NAME: ${{{{ github.workflow }}}}
   run: |


### PR DESCRIPTION
## Summary

- Point generated container smoke detection at `http://host.docker.internal:8080/reflect` instead of container loopback.
- Regenerate the Copilot, Claude, and Codex container smoke lock files.
- Update the Codex CLI fallback to pass the prompt as the supported positional `codex exec` prompt instead of using unsupported `--prompt-file`.

## Why

Container smoke detection was falling back to engine CLIs because `/reflect` was configured as `http://127.0.0.1:8080/reflect` inside the AWF container, where that points at container loopback and returns connection refused. Claude happened to succeed via CLI fallback, but Copilot and Codex did not. Codex also failed explicitly because `@openai/codex@0.128.0` rejects `codex exec --prompt-file`.

## Validation

- `python3 scripts/create-threat-detection-sibling-workflows.py --check`
- `go test ./...`
- `make docker-smoke IMAGE_TAG=reflect-and-codex-fix`