### PR TITLE
Log reflect responses for detection debugging

### DIFF
--- a/.github/workflows/detection-only.yml
+++ b/.github/workflows/detection-only.yml
@@ -222,6 +222,7 @@ jobs:
           # The api-proxy hostname returns 403 from this detection-only AWF path; target the internal api-proxy IP instead.
           # THREAT_DETECTION_REFLECT_URL: http://api-proxy:10000/reflect
           THREAT_DETECTION_REFLECT_URL: http://172.30.0.30:10000/reflect
+          THREAT_DETECTION_LOG_REFLECT_RESPONSE: "true"
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Copilot engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ responses fail safe into the full detector. The full detector preserves the
 existing CLI engine behavior and prefers `/reflect` structured output when a
 schema-capable model is available.
 
+Set `THREAT_DETECTION_LOG_REFLECT_RESPONSE=true` to print raw `/reflect`
+responses to stderr for controlled debugging. Responses may include reflected
+artifact content, so leave this disabled outside targeted diagnostic runs.
+
 **Exit codes:**
 - `0` — Safe (no threats detected)
 - `1` — Threat detected

--- a/pkg/engine/reflect.go
+++ b/pkg/engine/reflect.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,6 +108,7 @@ func (c *ReflectClient) ListModels(ctx context.Context) ([]ReflectModel, error) 
 	if err != nil {
 		return nil, fmt.Errorf("reading reflect model list: %w", err)
 	}
+	printReflectResponse(os.Stderr, http.MethodGet, resp.Status, body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("listing reflect models returned %s: %s", resp.Status, responseBodyPreview(body))
 	}
@@ -135,10 +138,31 @@ func (c *ReflectClient) postReflect(ctx context.Context, payload map[string]any)
 	if err != nil {
 		return nil, fmt.Errorf("reading reflect response: %w", err)
 	}
+	printReflectResponse(os.Stderr, http.MethodPost, resp.Status, body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("reflect returned %s: %s", resp.Status, responseBodyPreview(body))
 	}
 	return body, nil
+}
+
+func printReflectResponse(w io.Writer, method, status string, body []byte) {
+	if !logReflectResponseEnabled() {
+		return
+	}
+	fmt.Fprintf(w, "::group::/reflect %s response (%s)\n%s", method, status, string(body))
+	if !bytes.HasSuffix(body, []byte("\n")) {
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintln(w, "::endgroup::")
+}
+
+func logReflectResponseEnabled() bool {
+	value := strings.TrimSpace(os.Getenv("THREAT_DETECTION_LOG_REFLECT_RESPONSE"))
+	if value == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(value)
+	return err == nil && enabled
 }
 
 func (c *ReflectClient) endpoint() string {

--- a/pkg/engine/reflect_test.go
+++ b/pkg/engine/reflect_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -131,6 +132,30 @@ func TestReflectClient_TruncatesNon2xxReflectError(t *testing.T) {
 	}
 	if !strings.Contains(msg, "...(truncated)") {
 		t.Fatalf("expected truncated preview in error: %q", msg)
+	}
+}
+
+func TestPrintReflectResponseHonorsEnv(t *testing.T) {
+	var buf bytes.Buffer
+
+	printReflectResponse(&buf, http.MethodGet, "200 OK", []byte(`{"models":[]}`))
+	if buf.Len() != 0 {
+		t.Fatalf("expected no debug output when env var is unset, got %q", buf.String())
+	}
+
+	buf.Reset()
+	t.Setenv("THREAT_DETECTION_LOG_REFLECT_RESPONSE", "true")
+	printReflectResponse(&buf, http.MethodGet, "200 OK", []byte(`{"models":[]}`))
+
+	got := buf.String()
+	for _, want := range []string{
+		"::group::/reflect GET response (200 OK)",
+		`{"models":[]}`,
+		"::endgroup::",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("debug output missing %q: %q", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Adds an opt-in debug path for printing raw /reflect responses during detection-only troubleshooting.

Summary:
- enables `THREAT_DETECTION_LOG_REFLECT_RESPONSE` in the detection-only workflow
- prints grouped GET/POST /reflect responses from the Go reflect client when the env var is true
- documents the debug env var and its artifact-content risk
- adds unit coverage for the logging helper, including the isolated enabled/disabled buffer phases

Verification:
- `gofmt -w pkg/engine/reflect.go pkg/engine/reflect_test.go`
- `git diff --check`
- `go test ./pkg/engine`