### PR TITLE
Emit structured terminal status line on stderr

### DIFF
--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -38,6 +39,33 @@ const (
 	detectionCorrectionInstruction = "Run the threat_detection_result command exactly once with --prompt-injection, --secret-leak, and --malicious-patch each set to true or false, plus a --reason for every threat set to true."
 )
 
+// statusPrefix is the marker for the single machine-readable status line
+// emitted to stderr at the end of every detection run. It is deliberately
+// distinct from the THREAT_DETECTION_RESULT: verdict prefix consumed by gh-aw
+// so the two never collide. Because the result JSON is not written on error
+// paths, this line is often the only structured signal a caller receives.
+const statusPrefix = "THREAT_DETECTION_STATUS:"
+
+// Terminal reasons reported on the status line. Exactly one is emitted per run.
+const (
+	reasonResultRecorded         = "result_recorded"          // verdict obtained (exit 0 or 1)
+	reasonConfigError            = "config_error"             // setup/validation failed before the engine ran
+	reasonEngineError            = "engine_error"             // engine subprocess failed without recording a verdict
+	reasonInvalidReportExhausted = "invalid_report_exhausted" // engine ran but never recorded a valid verdict across retries
+	reasonCancelled              = "cancelled"                // run was interrupted before a verdict
+	reasonOutputWriteError       = "output_write_error"       // verdict obtained but writing the result failed
+)
+
+// errEngineExecution marks a failure of the engine subprocess itself (as
+// opposed to the engine running but never recording a verdict). It lets run()
+// distinguish engine_error from invalid_report_exhausted on the status line.
+var errEngineExecution = errors.New("engine execution failed")
+
+// emitStatus writes the single terminal status line to stderr.
+func emitStatus(reason string, code int) {
+	fmt.Fprintf(os.Stderr, "%s reason=%s exit=%d\n", statusPrefix, reason, code)
+}
+
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "report-result" {
 		os.Exit(runReport(os.Args[2:]))
@@ -45,9 +73,18 @@ func main() {
 	os.Exit(run())
 }
 
-func run() int {
+func run() (code int) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
+
+	// reason is set at each terminal point; the deferred emitter writes the
+	// single status line. An empty reason (e.g. --version) emits nothing.
+	reason := ""
+	defer func() {
+		if reason != "" {
+			emitStatus(reason, code)
+		}
+	}()
 
 	var (
 		engineID   string
@@ -76,6 +113,7 @@ func run() int {
 	if len(args) < 1 {
 		fmt.Fprintf(os.Stderr, "Usage: threat-detect [flags] <artifacts-dir>\n")
 		flag.PrintDefaults()
+		reason = reasonConfigError
 		return exitError
 	}
 	artifactsDir := args[0]
@@ -84,6 +122,7 @@ func run() int {
 	arts, err := artifacts.Load(artifactsDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading artifacts: %v\n", err)
+		reason = reasonConfigError
 		return exitError
 	}
 
@@ -93,6 +132,7 @@ func run() int {
 		data, err := os.ReadFile(promptFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error reading prompt template: %v\n", err)
+			reason = reasonConfigError
 			return exitError
 		}
 		promptTemplate = string(data)
@@ -101,6 +141,7 @@ func run() int {
 	prompt, err := detector.BuildPrompt(arts, promptTemplate)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error building prompt: %v\n", err)
+		reason = reasonConfigError
 		return exitError
 	}
 
@@ -108,6 +149,7 @@ func run() int {
 	eng, err := engine.New(engineID, model)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating engine: %v\n", err)
+		reason = reasonConfigError
 		return exitError
 	}
 
@@ -115,6 +157,7 @@ func run() int {
 	sinkFile, err := os.CreateTemp("", "threat-detect-result-*.json")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating result sink: %v\n", err)
+		reason = reasonConfigError
 		return exitError
 	}
 	sinkPath := sinkFile.Name()
@@ -126,10 +169,21 @@ func run() int {
 	result, err := analyzeWithRetries(ctx, eng, prompt, sinkPath, retries)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error running detection: %v\n", err)
+		switch {
+		case ctx.Err() != nil:
+			reason = reasonCancelled
+		case errors.Is(err, errEngineExecution):
+			reason = reasonEngineError
+		default:
+			reason = reasonInvalidReportExhausted
+		}
 		return exitError
 	}
 
-	return writeResult(result, outputJSON)
+	var resultReason string
+	code, resultReason = writeResult(result, outputJSON)
+	reason = resultReason
+	return code
 }
 
 func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath string, retries int) (*detector.Result, error) {
@@ -146,7 +200,7 @@ func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath
 		// Remove any stale sink result before each attempt.
 		os.Remove(sinkPath)
 		if _, err := eng.Analyze(ctx, currentPrompt, engine.AnalyzeOptions{ResultSinkPath: sinkPath}); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", errEngineExecution, err)
 		}
 		// The verdict must be reported in-session through the
 		// threat_detection_result tool, which records it to the sink.
@@ -160,17 +214,20 @@ func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath
 	return nil, fmt.Errorf("detection model did not record a verdict via the threat_detection_result tool after %d attempt(s): %w", attempts, lastErr)
 }
 
-func writeResult(result *detector.Result, outputJSON string) int {
+// writeResult marshals and writes the verdict, returning the exit code and the
+// terminal reason for the status line. The result JSON is only ever produced on
+// the success path; an output failure yields no JSON and reasonOutputWriteError.
+func writeResult(result *detector.Result, outputJSON string) (int, string) {
 	jsonBytes, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error marshaling result: %v\n", err)
-		return exitError
+		return exitError, reasonOutputWriteError
 	}
 
 	if outputJSON != "" {
 		if err := os.WriteFile(outputJSON, jsonBytes, 0o600); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing output: %v\n", err)
-			return exitError
+			return exitError, reasonOutputWriteError
 		}
 	} else {
 		fmt.Println(string(jsonBytes))
@@ -178,9 +235,9 @@ func writeResult(result *detector.Result, outputJSON string) int {
 
 	// Exit code based on threat detection
 	if result.HasThreats() {
-		return exitThreat
+		return exitThreat, reasonResultRecorded
 	}
-	return exitSafe
+	return exitSafe, reasonResultRecorded
 }
 
 func envInt(key string, fallback int) int {

--- a/cmd/threat-detect/main_test.go
+++ b/cmd/threat-detect/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -43,7 +44,12 @@ func TestRunPrefersSinkResultOverTranscript(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
 	sinkJSON := `{"prompt_injection":true,"secret_leak":false,"malicious_patch":false,"reasons":["from sink"]}`
-	fakeBinDir := writeFakeCopilotWithSink(t, copilotMarker, sinkJSON, 0)
+	// stdout carries a conflicting legacy THREAT_DETECTION_RESULT line that
+	// reports a *safe* verdict. The sink (first valid result) must win and the
+	// transcript line must be ignored entirely; if stdout scraping is ever
+	// reintroduced, this test fails.
+	conflictingStdout := `THREAT_DETECTION_RESULT:{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":["from transcript"]}`
+	fakeBinDir := writeFakeCopilotWithSinkAndStdout(t, copilotMarker, sinkJSON, conflictingStdout, 0)
 
 	code := runWithTestArgs(t, []string{
 		"threat-detect",
@@ -66,6 +72,36 @@ func TestRunPrefersSinkResultOverTranscript(t *testing.T) {
 	reasons, _ := result["reasons"].([]any)
 	if len(reasons) != 1 || reasons[0].(string) != "from sink" {
 		t.Fatalf("expected sink reasons, got %#v", result["reasons"])
+	}
+}
+
+func TestRunEngineFailsWithoutSinkResult(t *testing.T) {
+	artifactsDir := t.TempDir()
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	// The engine emits a legacy-looking safe verdict on stdout but exits
+	// non-zero without ever recording a sink result. A killed/failed engine
+	// without a valid sink verdict must NOT be treated as success: detection
+	// must fail closed with the infrastructure exit code and write no result.
+	stdout := `THREAT_DETECTION_RESULT:{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotFailing(t, copilotMarker, stdout, 1)
+
+	code := runWithTestArgs(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+
+	if code != exitError {
+		t.Fatalf("run() exit code = %d, want %d (fail closed)", code, exitError)
+	}
+	if _, err := os.Stat(copilotMarker); err != nil {
+		t.Fatalf("expected copilot to run: %v", err)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no result file to be written, stat err = %v", err)
 	}
 }
 
@@ -100,13 +136,76 @@ func TestRunEarlyTerminationOnSink(t *testing.T) {
 	}
 }
 
+func TestRunEmitsResultRecordedStatus(t *testing.T) {
+	artifactsDir := t.TempDir()
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":true,"secret_leak":false,"malicious_patch":false,"reasons":["agentic detection"]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, copilotMarker, sinkJSON, 0)
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+
+	if code != exitThreat {
+		t.Fatalf("run() exit code = %d, want %d", code, exitThreat)
+	}
+	want := "THREAT_DETECTION_STATUS: reason=result_recorded exit=1"
+	if !strings.Contains(stderr, want) {
+		t.Fatalf("stderr missing status line %q, got:\n%s", want, stderr)
+	}
+}
+
+func TestRunEmitsEngineErrorStatusOnFailClosed(t *testing.T) {
+	artifactsDir := t.TempDir()
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	// Engine dies without recording a sink verdict: fail closed with exit 2 and
+	// an engine_error status line, even though no result JSON is written.
+	stdout := `THREAT_DETECTION_RESULT:{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotFailing(t, copilotMarker, stdout, 1)
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+
+	if code != exitError {
+		t.Fatalf("run() exit code = %d, want %d (fail closed)", code, exitError)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no result file to be written, stat err = %v", err)
+	}
+	want := "THREAT_DETECTION_STATUS: reason=engine_error exit=2"
+	if !strings.Contains(stderr, want) {
+		t.Fatalf("stderr missing status line %q, got:\n%s", want, stderr)
+	}
+}
+
 func runWithTestArgs(t *testing.T, args []string, env map[string]string) int {
+	t.Helper()
+	code, _ := runWithTestArgsCapture(t, args, env)
+	return code
+}
+
+// runWithTestArgsCapture runs the CLI like runWithTestArgs but also captures
+// everything written to os.Stderr so tests can assert the status line.
+func runWithTestArgsCapture(t *testing.T, args []string, env map[string]string) (int, string) {
 	t.Helper()
 	originalArgs := os.Args
 	originalFlags := flag.CommandLine
+	originalStderr := os.Stderr
 	t.Cleanup(func() {
 		os.Args = originalArgs
 		flag.CommandLine = originalFlags
+		os.Stderr = originalStderr
 	})
 	os.Args = args
 	flag.CommandLine = flag.NewFlagSet(args[0], flag.ContinueOnError)
@@ -115,10 +214,37 @@ func runWithTestArgs(t *testing.T, args []string, env map[string]string) int {
 		t.Setenv(key, value)
 	}
 
-	return run()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating stderr pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	code := run()
+	w.Close()
+	os.Stderr = originalStderr
+	stderr := <-done
+	r.Close()
+
+	return code, stderr
 }
 
 func writeFakeCopilotWithSink(t *testing.T, markerPath, sinkJSON string, sleepSeconds int) string {
+	t.Helper()
+	return writeFakeCopilotWithSinkAndStdout(t, markerPath, sinkJSON, "no result line here", sleepSeconds)
+}
+
+// writeFakeCopilotWithSinkAndStdout writes a fake copilot that records a valid
+// verdict to $THREAT_DETECTION_RESULT_FILE (simulating the model calling the
+// report tool), emits stdoutLine on stdout, then optionally sleeps for
+// sleepSeconds to exercise early termination.
+func writeFakeCopilotWithSinkAndStdout(t *testing.T, markerPath, sinkJSON, stdoutLine string, sleepSeconds int) string {
 	t.Helper()
 
 	binDir := t.TempDir()
@@ -128,13 +254,35 @@ func writeFakeCopilotWithSink(t *testing.T, markerPath, sinkJSON string, sleepSe
 		"cat >/dev/null",
 		"printf called > " + shellQuote(markerPath),
 		"printf '%s' " + shellQuote(sinkJSON) + " > \"$THREAT_DETECTION_RESULT_FILE\"",
-		"printf 'no result line here\\n'",
+		"printf '%s\\n' " + shellQuote(stdoutLine),
 	}
 	if sleepSeconds > 0 {
 		lines = append(lines, "sleep "+strconv.Itoa(sleepSeconds))
 	}
 	lines = append(lines, "")
 	if err := os.WriteFile(scriptPath, []byte(strings.Join(lines, "\n")), 0o700); err != nil {
+		t.Fatalf("writing fake copilot: %v", err)
+	}
+	return binDir
+}
+
+// writeFakeCopilotFailing writes a fake copilot that emits stdout, never writes
+// the sink, and exits with exitCode — simulating an engine that dies without
+// reporting a verdict.
+func writeFakeCopilotFailing(t *testing.T, markerPath, stdout string, exitCode int) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	scriptPath := filepath.Join(binDir, "copilot")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"cat >/dev/null",
+		"printf called > " + shellQuote(markerPath),
+		"printf '%s\\n' " + shellQuote(stdout),
+		"exit " + strconv.Itoa(exitCode),
+		"",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
 		t.Fatalf("writing fake copilot: %v", err)
 	}
 	return binDir


### PR DESCRIPTION
## Summary

Adds a single machine-readable **status line** to stderr at the end of every detection run, and hardens the detection tests around the sink-only verdict path.

```
THREAT_DETECTION_STATUS: reason=<reason> exit=<code>
```

Fixes #238
(after the previous simplifications)

### Why

The result JSON is only written on the **success path**. On every error path (config error, engine crash, no verdict recorded, cancellation) `--output` is *not* written and nothing is printed to stdout — the only signal today is the exit code plus free-text stderr. This status line gives callers a deterministic, greppable artifact precisely when the JSON is absent.

The prefix is intentionally distinct from `THREAT_DETECTION_RESULT:` so it never collides with the verdict line gh-aw consumes.

### Terminal reasons (exactly one per run)

| reason | exit | when |
|---|---|---|
| `result_recorded` | 0 / 1 | verdict obtained (safe / threat) |
| `config_error` | 2 | usage, artifact load, prompt-template, BuildPrompt, engine.New, sink create |
| `engine_error` | 2 | engine subprocess failed without a verdict |
| `invalid_report_exhausted` | 2 | engine ran but never recorded a valid verdict across retries |
| `cancelled` | 2 | interrupted before a verdict |
| `output_write_error` | 2 | verdict obtained but writing the result failed |

`--version` emits no status line. `engine_error` is distinguished from `invalid_report_exhausted` via an `errEngineExecution` sentinel; `cancelled` via `ctx.Err()`.

### Tests

- `TestRunEmitsResultRecordedStatus` — asserts `reason=result_recorded exit=1` on the success path.
- `TestRunEmitsEngineErrorStatusOnFailClosed` — asserts `reason=engine_error exit=2` and **no result file** written.
- Strengthened `TestRunPrefersSinkResultOverTranscript` (sink verdict wins over a conflicting transcript line) and `TestRunEngineFailsWithoutSinkResult` (failed engine without sink result fails closed).
- New `runWithTestArgsCapture` helper captures stderr.

All tests pass under `-race`; gofmt and vet clean.

### Notes

- No change to the result JSON contract — this is stderr-only, so gh-aw's parser is unaffected.
- `timeout` is intentionally omitted: the CLI sets no deadline, so an external kill surfaces as `cancelled`/`engine_error`.