### PR TITLE
fix(smoke): pass explicit detection model in container siblings for AWF BYOK

### DIFF
--- a/.github/workflows/smoke-claude-container.lock.yml
+++ b/.github/workflows/smoke-claude-container.lock.yml
@@ -1430,7 +1430,7 @@ jobs:
         timeout-minutes: 20
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_CLAUDE || '' }}
+          THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_CLAUDE || vars.GH_AW_DEFAULT_MODEL_CLAUDE || '' }}
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Claude engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |

--- a/.github/workflows/smoke-codex-container.lock.yml
+++ b/.github/workflows/smoke-codex-container.lock.yml
@@ -1488,7 +1488,7 @@ jobs:
         timeout-minutes: 20
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
-          THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_CODEX || '' }}
+          THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_CODEX || vars.GH_AW_DEFAULT_MODEL_CODEX || 'gpt-5.4' }}
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Codex engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |

--- a/.github/workflows/smoke-copilot-container.lock.yml
+++ b/.github/workflows/smoke-copilot-container.lock.yml
@@ -1364,7 +1364,7 @@ jobs:
         timeout-minutes: 20
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
+          THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Copilot engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |

--- a/scripts/create-threat-detection-sibling-workflows.py
+++ b/scripts/create-threat-detection-sibling-workflows.py
@@ -74,6 +74,19 @@ def engine_env(engine: str) -> str:
     raise ValueError(f"unsupported engine: {engine}")
 
 
+def detection_model_expr(engine: str) -> str:
+    # Mirror the model defaults the gh-aw-generated smokes use for the detection
+    # phase. Under AWF token steering the engine CLI runs in BYOK/offline mode,
+    # which requires an explicit model (an empty model breaks Copilot/Codex).
+    if engine == "copilot":
+        return "${{ vars.GH_AW_MODEL_DETECTION_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}"
+    if engine == "claude":
+        return "${{ vars.GH_AW_MODEL_DETECTION_CLAUDE || vars.GH_AW_DEFAULT_MODEL_CLAUDE || '' }}"
+    if engine == "codex":
+        return "${{ vars.GH_AW_MODEL_DETECTION_CODEX || vars.GH_AW_DEFAULT_MODEL_CODEX || 'gpt-5.4' }}"
+    raise ValueError(f"unsupported engine: {engine}")
+
+
 def replacement_steps(engine: str, workflow_description: str, awf_config_line: str, awf_command_line: str, awf_credits_line: str = "") -> str:
     runner_temp = "${RUNNER_TEMP}"
     credits_block = indent(awf_credits_line, 4) + "\n" if awf_credits_line else ""
@@ -122,7 +135,7 @@ def replacement_steps(engine: str, workflow_description: str, awf_config_line: s
   timeout-minutes: 20
   env:
 {indent(engine_env(engine), 4)}
-    THREAT_DETECTION_MODEL: ${{{{ vars.GH_AW_MODEL_DETECTION_{engine.upper()} || '' }}}}
+    THREAT_DETECTION_MODEL: {detection_model_expr(engine)}
     WORKFLOW_DESCRIPTION: {workflow_description}
     WORKFLOW_NAME: ${{{{ github.workflow }}}}
   run: |


### PR DESCRIPTION
## Problem

The `Smoke {Copilot,Claude,Codex} Containerized` detection jobs fail. After fixing the malformed AWF config JSON (empty `GH_AW_MAX_AI_CREDITS`), the detector ran but the Copilot CLI failed on every retry with:

```
BYOK providers require an explicit model. Run `copilot help providers` for configuration details.
```

## Root cause

Under AWF with `apiProxy.enableTokenSteering`, the engine CLI runs in BYOK/offline mode, which **requires an explicit model**. The detector forwards the model to Copilot via `COPILOT_MODEL` only when non-empty (`pkg/engine/engine.go`). The generated container siblings set:

```yaml
THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
```

which is empty when the repo var is unset, so no model reached the CLI. The gh-aw-generated smokes instead default to a real model (`claude-sonnet-4.6` for copilot, `gpt-5.4` for codex).

## Fix

Added `detection_model_expr(engine)` to `scripts/create-threat-detection-sibling-workflows.py` so the generated `THREAT_DETECTION_MODEL` mirrors the original detection-phase defaults:

- copilot → `... || GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6'`
- claude → `... || GH_AW_DEFAULT_MODEL_CLAUDE || ''`
- codex → `... || GH_AW_DEFAULT_MODEL_CODEX || 'gpt-5.4'`

Regenerated all three `*-container.lock.yml` siblings; `--check` passes.

Workflow-only change — no detector release required to test.