### PR TITLE
fix(smoke): set OPENAI_API_KEY for codex container sibling so AWF api-proxy steers it

### DIFF
--- a/.github/workflows/smoke-codex-container.lock.yml
+++ b/.github/workflows/smoke-codex-container.lock.yml
@@ -1488,6 +1488,7 @@ jobs:
         timeout-minutes: 20
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           THREAT_DETECTION_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_CODEX || vars.GH_AW_DEFAULT_MODEL_CODEX || 'gpt-5.4' }}
           WORKFLOW_DESCRIPTION: "Smoke test workflow that validates Codex engine execution in this repository"
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/scripts/create-threat-detection-sibling-workflows.py
+++ b/scripts/create-threat-detection-sibling-workflows.py
@@ -70,7 +70,13 @@ def engine_env(engine: str) -> str:
     if engine == "claude":
         return """ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}"""
     if engine == "codex":
-        return """CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}"""
+        # The codex CLI authenticates with OPENAI_API_KEY; CODEX_API_KEY alone
+        # leaves it without an auth header (401 from api.openai.com). Mirror the
+        # gh-aw-generated codex smoke, which sets both.
+        return (
+            "CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}\n"
+            "OPENAI_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}"
+        )
     raise ValueError(f"unsupported engine: {engine}")
 
 


### PR DESCRIPTION
## Problem

`Smoke Codex Containerized` detection fails. The detector runs, but the codex CLI fails every reconnect with:

```
ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses
ERROR: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header
```

## Root cause

AWF's api-proxy sidecar reads the provider key from the **`awf` process environment** (the step env, via `sudo -E`) to hold it securely, then auto-sets `OPENAI_BASE_URL` in the agent container to point at the sidecar; `--exclude-env OPENAI_API_KEY` then strips the raw key from the agent for credential isolation.

The codex container sibling only set `CODEX_API_KEY`, which the api-proxy does not recognize. The AWF logs show:

```
[INFO] API proxy enabled: OpenAI=false, Anthropic=false, Copilot=false, Gemini=false
[WARN] ⚠️  API proxy enabled but no API keys found in environment
[health-check] No API proxy configured (... OPENAI_BASE_URL ... not set)
```

With no `OPENAI_BASE_URL`, codex connected to `api.openai.com` directly with no auth → 401.

## Fix

Mirror the gh-aw-generated codex smoke, which sets **both** `CODEX_API_KEY` and `OPENAI_API_KEY` in the detection step env. Updated `engine_env('codex')` in `scripts/create-threat-detection-sibling-workflows.py` and regenerated the codex container sibling. The `--exclude-env OPENAI_API_KEY` in the inherited AWF command is expected — the sidecar holds the key while the agent does not.

Workflow-only change — no detector release required to test.