### PR TITLE
chore: upgrade Go to version 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - run: go vet ./...
 
   test:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - run: go test -v -race -coverprofile=coverage.out ./...
       - name: Upload coverage
         uses: actions/upload-artifact@v4
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - run: go build -o bin/threat-detect ./cmd/threat-detect
       - name: Upload binary
         uses: actions/upload-artifact@v4
@@ -53,6 +53,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - name: Build and smoke test binary
         run: make smoke

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
 
       - name: Run tests
         run: make test

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
 
       - name: Build main binary
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
 
       - name: Run tests
         run: go test -v -race ./...

--- a/.github/workflows/smoke-claude-container.lock.yml
+++ b/.github/workflows/smoke-claude-container.lock.yml
@@ -429,7 +429,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: Capture GOROOT for AWF chroot mode
         run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke-claude-container.md
+++ b/.github/workflows/smoke-claude-container.md
@@ -24,7 +24,7 @@ tools:
   github:
 runtimes:
   go:
-    version: "1.23"
+    version: "1.26"
 checkout:
   fetch-depth: 1
 safe-outputs:

--- a/.github/workflows/smoke-claude.lock.yml
+++ b/.github/workflows/smoke-claude.lock.yml
@@ -428,7 +428,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: Capture GOROOT for AWF chroot mode
         run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke-claude.md
+++ b/.github/workflows/smoke-claude.md
@@ -24,7 +24,7 @@ tools:
   github:
 runtimes:
   go:
-    version: "1.23"
+    version: "1.26"
 checkout:
   fetch-depth: 1
 safe-outputs:

--- a/.github/workflows/smoke-codex-container.lock.yml
+++ b/.github/workflows/smoke-codex-container.lock.yml
@@ -431,7 +431,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: Capture GOROOT for AWF chroot mode
         run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke-codex-container.md
+++ b/.github/workflows/smoke-codex-container.md
@@ -22,7 +22,7 @@ tools:
   web-fetch:
 runtimes:
   go:
-    version: "1.23"
+    version: "1.26"
 checkout:
   fetch-depth: 1
 safe-outputs:

--- a/.github/workflows/smoke-codex.lock.yml
+++ b/.github/workflows/smoke-codex.lock.yml
@@ -430,7 +430,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: Capture GOROOT for AWF chroot mode
         run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke-codex.md
+++ b/.github/workflows/smoke-codex.md
@@ -22,7 +22,7 @@ tools:
   web-fetch:
 runtimes:
   go:
-    version: "1.23"
+    version: "1.26"
 checkout:
   fetch-depth: 1
 safe-outputs:

--- a/.github/workflows/smoke-copilot-container.lock.yml
+++ b/.github/workflows/smoke-copilot-container.lock.yml
@@ -423,7 +423,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: Capture GOROOT for AWF chroot mode
         run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke-copilot-container.md
+++ b/.github/workflows/smoke-copilot-container.md
@@ -24,7 +24,7 @@ tools:
   web-fetch:
 runtimes:
   go:
-    version: "1.23"
+    version: "1.26"
 checkout:
   fetch-depth: 1
 safe-outputs:

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -422,7 +422,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: Capture GOROOT for AWF chroot mode
         run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke-copilot.md
+++ b/.github/workflows/smoke-copilot.md
@@ -24,7 +24,7 @@ tools:
   web-fetch:
 runtimes:
   go:
-    version: "1.23"
+    version: "1.26"
 checkout:
   fetch-depth: 1
 safe-outputs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ It detects three categories: **prompt injection**, **secret leak**, and **malici
 
 ### Key facts
 
-- **Language**: Go 1.23+ (module `github.com/github/gh-aw-threat-detection`)
+- **Language**: Go 1.26+ (module `github.com/github/gh-aw-threat-detection`)
 - **Binary**: `bin/threat-detect` (built via `make build`)
 - **Distribution**: published as GitHub Release assets (`threat-detect-linux-amd64` + `checksums.txt`); no container image
 - **Spec**: [`specs/threat-detection-spec.md`](specs/threat-detection-spec.md) — W3C-style normative spec; the source of truth for behavior

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ No additional secrets are required for unit tests, `make build`, `make test`, or
 
 ### Prerequisites
 
-- Go 1.23+
+- Go 1.26+
 
 ### AW Smoke Workflows
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/github/gh-aw-threat-detection
 
-go 1.23.0
+go 1.26.0


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KXGX20GJ15WB6KGG2BEG31Y0)

Closes #378

## Summary

Upgrades the project's Go version from **1.23 to 1.26** across the repository.

## Changes

- **`go.mod`**: `go 1.23.0` → `go 1.26.0`
- **CI/release workflows**: `ci.yml`, `release.yml`, `publish-main.yml`, `create-release-tag.yml` (`go-version: '1.26'`)
- **Smoke workflows**: all `smoke-{copilot,claude,codex}[-container].md` sources (`runtimes.go.version: "1.26"`) and their compiled `.lock.yml` files (`go-version: '1.26'`)
- **Docs**: `README.md`, `CLAUDE.md`, `AGENTS.md` (Go 1.23+ → 1.26+)

## Notes

- `license-check.yml` and `replay-detection.yml` use `go-version-file: go.mod`, so they automatically pick up 1.26.
- The devcontainer's `go:1-bookworm` image tracks the latest 1.x, so it needs no change.
- Go is not installed in this sandbox, so `make build`/`make test` could not be run here; CI will validate compilation against 1.26.