### PR TITLE
feat(release): support Linux arm64 detector builds

### DIFF
--- a/.github/workflows/detection-only.yml
+++ b/.github/workflows/detection-only.yml
@@ -198,16 +198,21 @@ jobs:
           set -euo pipefail
           dest_dir="${RUNNER_TEMP}/gh-aw/threat-detect-bin"
           mkdir -p "$dest_dir"
+          case "$(uname -m)" in
+            x86_64) asset="threat-detect-linux-amd64" ;;
+            aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+            *) echo "::error::Unsupported runner architecture: $(uname -m)"; exit 1 ;;
+          esac
           download_dir="$(mktemp -d)"
           trap 'rm -rf "$download_dir"' EXIT
-          args=(--repo "$DETECTOR_REPO" --pattern threat-detect-linux-amd64 --pattern checksums.txt --dir "$download_dir")
+          args=(--repo "$DETECTOR_REPO" --pattern "$asset" --pattern checksums.txt --dir "$download_dir")
           if [ -n "${THREAT_DETECTION_VERSION:-}" ]; then
             gh release download "$THREAT_DETECTION_VERSION" "${args[@]}"
           else
             gh release download "${args[@]}"
           fi
           ( cd "$download_dir" && sha256sum --check --ignore-missing checksums.txt )
-          install -m 0755 "$download_dir/threat-detect-linux-amd64" "$dest_dir/threat-detect"
+          install -m 0755 "$download_dir/$asset" "$dest_dir/threat-detect"
       - name: Execute threat detection with AWF
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -28,44 +28,49 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          ASSET="threat-detect-linux-amd64"
           RELEASE_INFO=$(gh release view "$PROMOTE_TAG" --json body,isPrerelease,tagName)
           IS_PRERELEASE=$(echo "$RELEASE_INFO" | jq -r '.isPrerelease')
           if [ "$IS_PRERELEASE" != "true" ]; then
             echo "::error::Release ${PROMOTE_TAG} is not a prerelease. Nothing to promote."
             exit 1
           fi
-          # Extract the recorded binary asset digest from the release body.
-          DIGEST_LINE_PREFIX="Binary asset sha256: sha256:"
-          RECORDED_SHA256=""
-          while IFS= read -r line; do
-            case "$line" in
-              "$DIGEST_LINE_PREFIX"*)
-                RECORDED_SHA256="${line#Binary asset sha256: sha256:}"
-                break
-                ;;
-            esac
-          done < <(echo "$RELEASE_INFO" | jq -r '.body // ""')
-          if [ -z "$RECORDED_SHA256" ]; then
-            echo "::error::Release ${PROMOTE_TAG} does not record a binary asset sha256. Nothing to promote."
-            exit 1
-          fi
-          if ! echo "$RECORDED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
-            echo "::error::Release ${PROMOTE_TAG} records a binary asset sha256 with invalid format. Nothing to promote."
-            exit 1
-          fi
-          # Download the published asset and confirm it matches the recorded digest,
-          # so promotion can never mark a tampered or missing binary as Latest.
+          BODY="$(echo "$RELEASE_INFO" | jq -r '.body // ""')"
           tmp="$(mktemp -d)"
           trap 'rm -rf "$tmp"' EXIT
-          gh release download "$PROMOTE_TAG" --pattern "$ASSET" --dir "$tmp"
-          ACTUAL_SHA256="$(sha256sum "$tmp/$ASSET" | awk '{print $1}')"
-          if [ "$ACTUAL_SHA256" != "$RECORDED_SHA256" ]; then
-            echo "::error::Release ${PROMOTE_TAG} asset sha256 ${ACTUAL_SHA256} does not match recorded ${RECORDED_SHA256}. Nothing to promote."
-            exit 1
-          fi
-          echo "binary_sha256=sha256:${RECORDED_SHA256}" >> "$GITHUB_OUTPUT"
-          echo "✅ Verified ${PROMOTE_TAG} is a prerelease with binary asset sha256:${RECORDED_SHA256} — proceeding with promotion."
+          RECORDED_SUMMARY=""
+          for arch in amd64 arm64; do
+            ASSET="threat-detect-linux-${arch}"
+            # Extract the recorded per-arch binary asset digest from the release body.
+            DIGEST_LINE_PREFIX="Binary asset sha256 (linux-${arch}): sha256:"
+            RECORDED_SHA256=""
+            while IFS= read -r line; do
+              case "$line" in
+                *"${DIGEST_LINE_PREFIX}"*)
+                  RECORDED_SHA256="${line#*"${DIGEST_LINE_PREFIX}"}"
+                  RECORDED_SHA256="${RECORDED_SHA256%%[!0-9a-f]*}"
+                  break
+                  ;;
+              esac
+            done < <(printf '%s\n' "$BODY")
+            if [ -z "$RECORDED_SHA256" ]; then
+              echo "::error::Release ${PROMOTE_TAG} does not record a binary asset sha256 for linux-${arch}. Nothing to promote."
+              exit 1
+            fi
+            if ! echo "$RECORDED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
+              echo "::error::Release ${PROMOTE_TAG} records a binary asset sha256 for linux-${arch} with invalid format. Nothing to promote."
+              exit 1
+            fi
+            # Download the published asset and confirm it matches the recorded digest,
+            # so promotion can never mark a tampered or missing binary as Latest.
+            gh release download "$PROMOTE_TAG" --pattern "$ASSET" --dir "$tmp"
+            ACTUAL_SHA256="$(sha256sum "$tmp/$ASSET" | awk '{print $1}')"
+            if [ "$ACTUAL_SHA256" != "$RECORDED_SHA256" ]; then
+              echo "::error::Release ${PROMOTE_TAG} asset ${ASSET} sha256 ${ACTUAL_SHA256} does not match recorded ${RECORDED_SHA256}. Nothing to promote."
+              exit 1
+            fi
+            RECORDED_SUMMARY="${RECORDED_SUMMARY} linux-${arch}=sha256:${RECORDED_SHA256}"
+          done
+          echo "✅ Verified ${PROMOTE_TAG} is a prerelease with binary assets${RECORDED_SUMMARY} — proceeding with promotion."
 
       - name: Promote release to stable
         env:

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -26,10 +26,12 @@ jobs:
           SHORT_SHA="${GITHUB_SHA:0:7}"
           VERSION="main-${SHORT_SHA}"
           mkdir -p dist
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
-            -o dist/threat-detect-linux-amd64 ./cmd/threat-detect
-          ( cd dist && sha256sum threat-detect-linux-amd64 > checksums.txt )
+          for GOARCH in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="${GOARCH}" go build \
+              -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
+              -o "dist/threat-detect-linux-${GOARCH}" ./cmd/threat-detect
+          done
+          ( cd dist && sha256sum threat-detect-linux-amd64 threat-detect-linux-arm64 > checksums.txt )
           {
             echo "short_sha=${SHORT_SHA}"
             echo "version=${VERSION}"
@@ -41,7 +43,8 @@ jobs:
           SHORT_SHA: ${{ steps.build.outputs.short_sha }}
         run: |
           set -euo pipefail
-          BINARY_SHA256="sha256:$(sha256sum dist/threat-detect-linux-amd64 | awk '{print $1}')"
+          AMD64_SHA256="sha256:$(sha256sum dist/threat-detect-linux-amd64 | awk '{print $1}')"
+          ARM64_SHA256="sha256:$(sha256sum dist/threat-detect-linux-arm64 | awk '{print $1}')"
           # Move the rolling `main` pre-release to this commit. Deleting and
           # recreating keeps the `main` tag pointed at the freshest build, mirroring
           # the moving `:main` container tag. The Latest release (the most recently
@@ -49,9 +52,10 @@ jobs:
           gh release delete main --yes --cleanup-tag 2>/dev/null || true
           gh release create main \
             dist/threat-detect-linux-amd64#threat-detect-linux-amd64 \
+            dist/threat-detect-linux-arm64#threat-detect-linux-arm64 \
             dist/checksums.txt#checksums.txt \
             --title "main (edge build ${SHORT_SHA})" \
-            --notes "Unverified branch build from ${GITHUB_SHA}. Binary asset sha256: ${BINARY_SHA256}. The Latest release continues to track the most recently promoted version." \
+            --notes "Unverified branch build from ${GITHUB_SHA}. Binary asset sha256 (linux-amd64): ${AMD64_SHA256}. Binary asset sha256 (linux-arm64): ${ARM64_SHA256}. The Latest release continues to track the most recently promoted version." \
             --target "${GITHUB_SHA}" \
             --prerelease
 
@@ -63,7 +67,7 @@ jobs:
             echo "## Published main binary"
             echo
             echo "- Rolling pre-release \`main\` updated to edge build \`${SHORT_SHA}\`"
-            echo "- Asset: \`threat-detect-linux-amd64\` (+ \`checksums.txt\`)"
+            echo "- Asset: \`threat-detect-linux-amd64\`, \`threat-detect-linux-arm64\` (+ \`checksums.txt\`)"
             echo
             echo "These are unverified branch builds. The Latest release is unaffected and continues to track the most recently promoted release."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,20 @@ jobs:
       - name: Run tests
         run: go test -v -race ./...
 
-      - name: Build release binary
+      - name: Build release binaries
         run: |
           VERSION=${GITHUB_REF_NAME}
           mkdir -p dist
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
-            -o dist/threat-detect-linux-amd64 ./cmd/threat-detect
+          for GOARCH in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="${GOARCH}" go build \
+              -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
+              -o "dist/threat-detect-linux-${GOARCH}" ./cmd/threat-detect
+          done
 
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum threat-detect-linux-amd64 > checksums.txt
+          sha256sum threat-detect-linux-amd64 threat-detect-linux-arm64 > checksums.txt
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -59,13 +61,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Record the release-asset SHA-256 in the release body so the promote
-          # workflow can verify and pin the exact binary that was published.
-          BINARY_SHA256="sha256:$(sha256sum dist/threat-detect-linux-amd64 | awk '{print $1}')"
+          # Record the release-asset SHA-256 of each per-arch binary in the release
+          # body so the promote workflow can verify and pin the exact binaries that
+          # were published.
+          NOTES=""
+          for arch in amd64 arm64; do
+            SHA256="$(sha256sum "dist/threat-detect-linux-${arch}" | awk '{print $1}')"
+            NOTES="${NOTES}Binary asset sha256 (linux-${arch}): sha256:${SHA256}"$'\n'
+          done
           gh release create "${GITHUB_REF_NAME}" \
             dist/threat-detect-linux-amd64#threat-detect-linux-amd64 \
+            dist/threat-detect-linux-arm64#threat-detect-linux-arm64 \
             dist/checksums.txt#checksums.txt \
             --title "${GITHUB_REF_NAME}" \
-            --notes "Binary asset sha256: ${BINARY_SHA256}" \
+            --notes "${NOTES}" \
             --generate-notes \
             --prerelease

--- a/.github/workflows/replay-detection.yml
+++ b/.github/workflows/replay-detection.yml
@@ -306,12 +306,17 @@ jobs:
                 echo "::error::detector_ref must be set to a release tag when detector_source=release."
                 exit 1
               fi
+              case "$(uname -m)" in
+                x86_64) asset="threat-detect-linux-amd64" ;;
+                aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+                *) echo "::error::Unsupported runner architecture: $(uname -m)"; exit 1 ;;
+              esac
               gh release download "$DETECTOR_REF" \
                 --repo "$GITHUB_REPOSITORY" \
-                --pattern threat-detect-linux-amd64 \
+                --pattern "$asset" \
                 --dir "${RUNNER_TEMP}/gh-aw-replay/bin"
-              chmod +x "${RUNNER_TEMP}/gh-aw-replay/bin/threat-detect-linux-amd64"
-              echo "DETECTOR_BIN=${RUNNER_TEMP}/gh-aw-replay/bin/threat-detect-linux-amd64" >> "$GITHUB_ENV"
+              chmod +x "${RUNNER_TEMP}/gh-aw-replay/bin/$asset"
+              echo "DETECTOR_BIN=${RUNNER_TEMP}/gh-aw-replay/bin/$asset" >> "$GITHUB_ENV"
               ;;
             *)
               echo "::error::Unsupported detector_source '${DETECTOR_SOURCE}'."

--- a/.github/workflows/smoke-claude-container.lock.yml
+++ b/.github/workflows/smoke-claude-container.lock.yml
@@ -1409,16 +1409,21 @@ jobs:
           set -euo pipefail
           dest_dir="${RUNNER_TEMP}/gh-aw/threat-detect-bin"
           mkdir -p "$dest_dir"
+          case "$(uname -m)" in
+            x86_64) asset="threat-detect-linux-amd64" ;;
+            aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+            *) echo "::error::Unsupported runner architecture: $(uname -m)"; exit 1 ;;
+          esac
           download_dir="$(mktemp -d)"
           trap 'rm -rf "$download_dir"' EXIT
-          args=(--repo "$DETECTOR_REPO" --pattern threat-detect-linux-amd64 --pattern checksums.txt --dir "$download_dir")
+          args=(--repo "$DETECTOR_REPO" --pattern "$asset" --pattern checksums.txt --dir "$download_dir")
           if [ -n "${THREAT_DETECTION_VERSION:-}" ]; then
             gh release download "$THREAT_DETECTION_VERSION" "${args[@]}"
           else
             gh release download "${args[@]}"
           fi
           ( cd "$download_dir" && sha256sum --check --ignore-missing checksums.txt )
-          install -m 0755 "$download_dir/threat-detect-linux-amd64" "$dest_dir/threat-detect"
+          install -m 0755 "$download_dir/$asset" "$dest_dir/threat-detect"
       - name: Execute threat detection with AWF
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true

--- a/.github/workflows/smoke-codex-container.lock.yml
+++ b/.github/workflows/smoke-codex-container.lock.yml
@@ -1467,16 +1467,21 @@ jobs:
           set -euo pipefail
           dest_dir="${RUNNER_TEMP}/gh-aw/threat-detect-bin"
           mkdir -p "$dest_dir"
+          case "$(uname -m)" in
+            x86_64) asset="threat-detect-linux-amd64" ;;
+            aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+            *) echo "::error::Unsupported runner architecture: $(uname -m)"; exit 1 ;;
+          esac
           download_dir="$(mktemp -d)"
           trap 'rm -rf "$download_dir"' EXIT
-          args=(--repo "$DETECTOR_REPO" --pattern threat-detect-linux-amd64 --pattern checksums.txt --dir "$download_dir")
+          args=(--repo "$DETECTOR_REPO" --pattern "$asset" --pattern checksums.txt --dir "$download_dir")
           if [ -n "${THREAT_DETECTION_VERSION:-}" ]; then
             gh release download "$THREAT_DETECTION_VERSION" "${args[@]}"
           else
             gh release download "${args[@]}"
           fi
           ( cd "$download_dir" && sha256sum --check --ignore-missing checksums.txt )
-          install -m 0755 "$download_dir/threat-detect-linux-amd64" "$dest_dir/threat-detect"
+          install -m 0755 "$download_dir/$asset" "$dest_dir/threat-detect"
       - name: Execute threat detection with AWF
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true

--- a/.github/workflows/smoke-copilot-container.lock.yml
+++ b/.github/workflows/smoke-copilot-container.lock.yml
@@ -1343,16 +1343,21 @@ jobs:
           set -euo pipefail
           dest_dir="${RUNNER_TEMP}/gh-aw/threat-detect-bin"
           mkdir -p "$dest_dir"
+          case "$(uname -m)" in
+            x86_64) asset="threat-detect-linux-amd64" ;;
+            aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+            *) echo "::error::Unsupported runner architecture: $(uname -m)"; exit 1 ;;
+          esac
           download_dir="$(mktemp -d)"
           trap 'rm -rf "$download_dir"' EXIT
-          args=(--repo "$DETECTOR_REPO" --pattern threat-detect-linux-amd64 --pattern checksums.txt --dir "$download_dir")
+          args=(--repo "$DETECTOR_REPO" --pattern "$asset" --pattern checksums.txt --dir "$download_dir")
           if [ -n "${THREAT_DETECTION_VERSION:-}" ]; then
             gh release download "$THREAT_DETECTION_VERSION" "${args[@]}"
           else
             gh release download "${args[@]}"
           fi
           ( cd "$download_dir" && sha256sum --check --ignore-missing checksums.txt )
-          install -m 0755 "$download_dir/threat-detect-linux-amd64" "$dest_dir/threat-detect"
+          install -m 0755 "$download_dir/$asset" "$dest_dir/threat-detect"
       - name: Execute threat detection with AWF
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (and other coding agents) when workin
 The component runs in two main contexts:
 
 1. **As a host CLI** (`./bin/threat-detect <artifacts-dir>`) inside a `gh-aw`-generated detection job.
-2. **As a published release-asset binary** (`threat-detect-linux-amd64`, downloaded via `gh release download` from [`github/gh-aw-threat-detection` releases](https://github.com/github/gh-aw-threat-detection/releases)) installed on the runner and executed under the AWF firewall (see [AWF section below](#agentic-workflow-firewall-awf)).
+2. **As a published release-asset binary** (`threat-detect-linux-amd64` / `threat-detect-linux-arm64`, downloaded via `gh release download` from [`github/gh-aw-threat-detection` releases](https://github.com/github/gh-aw-threat-detection/releases)) installed on the runner and executed under the AWF firewall (see [AWF section below](#agentic-workflow-firewall-awf)).
 
 It detects three categories: **prompt injection**, **secret leak**, and **malicious patch**, and emits a strict JSON contract.
 
@@ -17,7 +17,7 @@ It detects three categories: **prompt injection**, **secret leak**, and **malici
 
 - **Language**: Go 1.26+ (module `github.com/github/gh-aw-threat-detection`)
 - **Binary**: `bin/threat-detect` (built via `make build`)
-- **Distribution**: published as GitHub Release assets (`threat-detect-linux-amd64` + `checksums.txt`); no container image
+- **Distribution**: published as GitHub Release assets (`threat-detect-linux-amd64`, `threat-detect-linux-arm64` + `checksums.txt`); no container image
 - **Spec**: [`specs/threat-detection-spec.md`](specs/threat-detection-spec.md) — W3C-style normative spec; the source of truth for behavior
 - **Engines supported**: `copilot` (default), `claude`, `codex` — invoked from `PATH`, not bundled into the binary
 - **Detection**: a single agentic CLI engine pass; the engine reports its verdict in-session via the `threat_detection_result` tool (out-of-band result sink), which is the sole source of the verdict
@@ -128,8 +128,8 @@ The detector reads the verdict exclusively from the out-of-band result sink. The
 Three workflows orchestrate releases:
 
 1. `.github/workflows/create-release-tag.yml` — manual; pushes `vX.Y.Z`.
-2. `.github/workflows/release.yml` — triggered by tag push; gated by `release-publish` environment; builds + publishes the `threat-detect-linux-amd64` binary as GitHub Release assets in a **prerelease**, recording the asset sha256 in the release notes.
-3. `.github/workflows/promote-release.yml` — manual; gated by `release-promote`; re-downloads the asset, verifies its sha256 against the recorded value, and marks the GitHub release **Latest** (stable).
+2. `.github/workflows/release.yml` — triggered by tag push; gated by `release-publish` environment; builds + publishes the `threat-detect-linux-amd64` and `threat-detect-linux-arm64` binaries as GitHub Release assets in a **prerelease**, recording each asset's sha256 in the release notes.
+3. `.github/workflows/promote-release.yml` — manual; gated by `release-promote`; re-downloads each per-arch asset, verifies its sha256 against the recorded value, and marks the GitHub release **Latest** (stable).
 
 The `latest` (non-prerelease) GitHub release and "Latest" badge **only move on explicit promotion** — never automatically.
 

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -188,8 +188,9 @@ Releases follow a **prerelease → promote** model:
 
 2. **Build & Publish (automated)** — pushing a tag matching `v*` triggers the
    [release workflow](.github/workflows/release.yml). It builds the
-   `threat-detect-linux-amd64` binary, attaches it (plus `checksums.txt`) to a
-   **prerelease** on GitHub, and records the asset sha256 in the release notes.
+   `threat-detect-linux-amd64` and `threat-detect-linux-arm64` binaries, attaches
+   them (plus `checksums.txt`) to a **prerelease** on GitHub, and records each
+   asset's sha256 in the release notes.
    The `release-publish` environment gate
    pauses the workflow before publishing so maintainers can abort if needed.
 
@@ -198,7 +199,7 @@ Releases follow a **prerelease → promote** model:
    **Actions → Promote Release → Run workflow**, entering the tag name. This
    workflow (gated by the `release-promote` environment):
    - verifies the release is still a prerelease
-   - re-downloads the asset and verifies its sha256 against the recorded value
+   - re-downloads each per-arch asset and verifies its sha256 against the recorded value
    - marks the GitHub release as stable and explicitly selects it as Latest (`--prerelease=false --latest`)
 
 The GitHub "Latest" release pointer only moves
@@ -211,9 +212,9 @@ In addition to release tags, every push to `main` triggers the
 [publish-main workflow](.github/workflows/publish-main.yml), which builds the
 binary and republishes a single rolling `main` pre-release:
 
-- The `main` pre-release always carries the `threat-detect-linux-amd64` asset
-  built from the most recent successful build from `main`, versioned
-  `main-<shortsha>`.
+- The `main` pre-release always carries the `threat-detect-linux-amd64` and
+  `threat-detect-linux-arm64` assets built from the most recent successful build
+  from `main`, versioned `main-<shortsha>`.
 
 These are **unverified branch builds**. The `main` pre-release is not eligible
 for promotion. The **Latest** stable release pointer is
@@ -240,7 +241,7 @@ After the tag is pushed:
 
 1. Approve the `release-publish` environment gate when the workflow pauses.
 2. Verify the prerelease on the [Releases page](../../releases) and test the
-   version-tagged `threat-detect-linux-amd64` asset.
+   version-tagged `threat-detect-linux-amd64` / `threat-detect-linux-arm64` assets.
 3. When satisfied, go to **Actions → Promote Release**, enter the tag, and run
    the workflow. Approve the `release-promote` environment gate.
 4. Confirm the **Latest** release now resolves to the new version.

--- a/README.md
+++ b/README.md
@@ -178,15 +178,20 @@ log artifact) together with `gh-aw`'s `logs` tooling.
 
 ### Released binary
 
-The `threat-detect` binary is published as a GitHub Release asset
-(`threat-detect-linux-amd64`) alongside a `checksums.txt`. Download and run it
+The `threat-detect` binary is published as GitHub Release assets for both Linux
+architectures (`threat-detect-linux-amd64` and `threat-detect-linux-arm64`)
+alongside a `checksums.txt`. Download the asset matching your runner and run it
 directly:
 
 ```bash
+case "$(uname -m)" in
+  x86_64) asset=threat-detect-linux-amd64 ;;
+  aarch64|arm64) asset=threat-detect-linux-arm64 ;;
+esac
 gh release download --repo github/gh-aw-threat-detection \
-  --pattern threat-detect-linux-amd64 --pattern checksums.txt
+  --pattern "$asset" --pattern checksums.txt
 sha256sum --check --ignore-missing checksums.txt
-install -m 0755 threat-detect-linux-amd64 ./threat-detect
+install -m 0755 "$asset" ./threat-detect
 ./threat-detect /path/to/artifacts
 ```
 
@@ -231,7 +236,7 @@ Replay uses the dispatching repository's `GITHUB_TOKEN`; no extra replay token i
 Common dispatch examples:
 
 - Current checkout, direct CLI replay: set `run_id`, leave `detector_source=current`, `engine=copilot`, and `use_awf=false`.
-- Released detector replay: set `detector_source=release` and `detector_ref` to a release tag such as `v0.0.2`. The workflow downloads the `threat-detect-linux-amd64` asset and runs it on the host so the selected engine CLI can be installed there.
+- Released detector replay: set `detector_source=release` and `detector_ref` to a release tag such as `v0.0.2`. The workflow downloads the `threat-detect-linux-<arch>` asset matching the runner and runs it on the host so the selected engine CLI can be installed there.
 - Model comparison: set `model` to the engine-specific model name to pass through `--model`.
 - Additional detection instructions: set `custom_prompt`; it is passed as `CUSTOM_PROMPT` and appended to the default detector prompt.
 - AWF mode: set `use_awf=true` only on a runner image that already provides the `awf` CLI. Direct mode is the default.
@@ -262,9 +267,10 @@ Decisions for the unresolved extraction questions:
 ## Release Asset Setup
 
 The repository can remain private while publishing release assets. The release
-workflow builds `threat-detect-linux-amd64`, records its sha256 in the release
-notes, and attaches it (plus `checksums.txt`) to a GitHub **prerelease** using
-the automatic `GITHUB_TOKEN` with `contents: write`.
+workflow builds `threat-detect-linux-amd64` and `threat-detect-linux-arm64`,
+records each binary's sha256 in the release notes, and attaches them (plus
+`checksums.txt`) to a GitHub **prerelease** using the automatic `GITHUB_TOKEN`
+with `contents: write`.
 
 Maintainers need to configure the following before the binary is consumed by `gh-aw`:
 
@@ -298,7 +304,7 @@ This repository includes three Agentic Workflows smoke tests:
 - `.github/workflows/smoke-claude.md`
 - `.github/workflows/smoke-codex.md`
 
-Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can be dispatched manually to start all three compiled smoke workflows and their three containerized siblings. The matching `.lock.yml` files are the compiled AW workflows. The `*-container.lock.yml` siblings are generated from those lock files by `scripts/create-threat-detection-sibling-workflows.py`; they download the released `threat-detect-linux-amd64` binary via `gh release download` and execute it under the same AWF wrapper used by the generated detection job. The script also copies matching `*-container.md` source sidecars from the original smoke markdown files so gh-aw's stale lock-file check can resolve and verify the inherited frontmatter hash.
+Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can be dispatched manually to start all three compiled smoke workflows and their three containerized siblings. The matching `.lock.yml` files are the compiled AW workflows. The `*-container.lock.yml` siblings are generated from those lock files by `scripts/create-threat-detection-sibling-workflows.py`; they download the released `threat-detect-linux-<arch>` binary matching the runner via `gh release download` and execute it under the same AWF wrapper used by the generated detection job. The script also copies matching `*-container.md` source sidecars from the original smoke markdown files so gh-aw's stale lock-file check can resolve and verify the inherited frontmatter hash.
 
 ### Detection-only Workflow
 
@@ -375,7 +381,7 @@ const DefaultThreatDetectionRepo    = "github/gh-aw-threat-detection"
 const DefaultThreatDetectionVersion = "v0.0.2"
 ```
 
-The detection job in compiled workflows downloads the pinned `threat-detect-linux-amd64` release asset and runs it instead of inline AI engine invocation.
+The detection job in compiled workflows downloads the pinned `threat-detect-linux-<arch>` release asset matching the runner and runs it instead of inline AI engine invocation.
 
 ## Specification
 

--- a/scripts/create-threat-detection-sibling-workflows.py
+++ b/scripts/create-threat-detection-sibling-workflows.py
@@ -164,16 +164,21 @@ def replacement_steps(engine: str, workflow_description: str, awf_config_line: s
     set -euo pipefail
     dest_dir="{runner_temp}/gh-aw/threat-detect-bin"
     mkdir -p "$dest_dir"
+    case "$(uname -m)" in
+      x86_64) asset="threat-detect-linux-amd64" ;;
+      aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+      *) echo "::error::Unsupported runner architecture: $(uname -m)"; exit 1 ;;
+    esac
     download_dir="$(mktemp -d)"
     trap 'rm -rf "$download_dir"' EXIT
-    args=(--repo "$DETECTOR_REPO" --pattern threat-detect-linux-amd64 --pattern checksums.txt --dir "$download_dir")
+    args=(--repo "$DETECTOR_REPO" --pattern "$asset" --pattern checksums.txt --dir "$download_dir")
     if [ -n "${{THREAT_DETECTION_VERSION:-}}" ]; then
       gh release download "$THREAT_DETECTION_VERSION" "${{args[@]}}"
     else
       gh release download "${{args[@]}}"
     fi
     ( cd "$download_dir" && sha256sum --check --ignore-missing checksums.txt )
-    install -m 0755 "$download_dir/threat-detect-linux-amd64" "$dest_dir/threat-detect"
+    install -m 0755 "$download_dir/$asset" "$dest_dir/threat-detect"
 - name: Execute threat detection with AWF
   if: always() && steps.detection_guard.outputs.run_detection == 'true'
   continue-on-error: true


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KXRKAPG2QVC059J5QJKDDXYA)

## Summary

Adds Linux **arm64** support so the detector runs on different runner architectures, not just amd64.

## Changes

**Build & publish**
- `release.yml` and `publish-main.yml` now build both `threat-detect-linux-amd64` and `threat-detect-linux-arm64`, add both to `checksums.txt`, and record each binary's sha256 in the release notes using per-arch lines: `Binary asset sha256 (linux-<arch>): sha256:<hash>`.

**Promotion**
- `promote-release.yml` re-downloads and verifies **both** per-arch assets against their recorded digests before marking a release Latest.

**Arch-aware consumers**
- `detection-only.yml`, `replay-detection.yml`, and the container smoke siblings now detect the runner arch via `uname -m` (`x86_64`→amd64, `aarch64|arm64`→arm64) and download the matching asset.
- `scripts/create-threat-detection-sibling-workflows.py` emits the arch-aware download shell; `*-container.lock.yml` files regenerated.

**Docs**
- README, DEVGUIDE, and CLAUDE.md updated to reflect the dual-arch assets and arch-aware download.

## Verification
- Cross-compiled the arm64 binary successfully.
- Validated the per-arch sha256 parsing logic used by promote.
- `make build` passes; sibling `--check` is clean; edited workflow YAML parses.