### PR TITLE
ci(smoke): dispatch standalone smoke workflows

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,6 +23,9 @@ jobs:
             smoke-copilot.lock.yml
             smoke-claude.lock.yml
             smoke-codex.lock.yml
+            smoke-copilot-standalone.lock.yml
+            smoke-claude-standalone.lock.yml
+            smoke-codex-standalone.lock.yml
             smoke-copilot-container.lock.yml
             smoke-claude-container.lock.yml
             smoke-codex-container.lock.yml


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KY2XD7VGXTTQNW7J5984316H)

## Summary

Adds the three `-standalone` smoke workflows to the top-level **Smoke** dispatch workflow so a single `workflow_dispatch` kicks off all nine smokes at once.

The dispatch list now covers:
- `smoke-{copilot,claude,codex}.lock.yml` (base)
- `smoke-{copilot,claude,codex}-standalone.lock.yml` (**new**)
- `smoke-{copilot,claude,codex}-container.lock.yml` (container siblings)

## Notes

Only `.github/workflows/smoke.yml` is changed. The container-sibling regeneration script (`create-threat-detection-sibling-workflows.py`) currently fails against the newer gh-aw v0.82.14 lock format (it looks for the old `sudo -E awf` / `printf … gh-aw-firewall` config lines, which the new compiler replaced with `awf --config …/awf-config.json`). That is a pre-existing issue and out of scope for this PR.