### PR TITLE
fix(engine): route codex through AWF proxy and honor detection model env vars

### DIFF
--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -134,6 +134,11 @@ func run() (code int) {
 		return exitSafe
 	}
 
+	// When --model is not set, fall back to the engine-specific detection model
+	// environment variable (GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}) so the
+	// standalone detector honors the model gh-aw configured for detection.
+	model = engine.ResolveModel(engineID, model)
+
 	// Reject a --log-file that collides with --output: they are opened and
 	// truncated independently, so sharing an inode would interleave the JSONL
 	// trace and the result JSON and corrupt both while still reporting success.

--- a/pkg/engine/codex.go
+++ b/pkg/engine/codex.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// codexConfigPath returns the path to the Codex config.toml, honoring CODEX_HOME
+// and falling back to ~/.codex/config.toml. It returns "" when neither can be
+// resolved.
+func codexConfigPath() string {
+	if home := os.Getenv("CODEX_HOME"); home != "" {
+		return filepath.Join(home, "config.toml")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".codex", "config.toml")
+	}
+	return ""
+}
+
+// codexForcedProvider inspects the Codex config file and returns the name of a
+// custom model provider that must be selected explicitly on the command line.
+//
+// It returns "" when the config already selects a provider at the top level
+// (which Codex honors), when the config cannot be read, or when no unambiguous
+// custom provider is defined. This repairs configs where the top-level
+// `model_provider` key was accidentally emitted under another table (for example
+// `[history]`), which Codex silently ignores — causing it to fall back to the
+// default `openai` provider and bypass the AWF API proxy.
+func codexForcedProvider(configPath string) string {
+	if configPath == "" {
+		return ""
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return ""
+	}
+	return parseCodexForcedProvider(string(data))
+}
+
+// parseCodexForcedProvider scans TOML content for a top-level `model_provider`
+// selection and any `[model_providers.<name>]` tables. See codexForcedProvider
+// for the return-value semantics.
+func parseCodexForcedProvider(content string) string {
+	section := "" // current table header; "" means top level
+	topLevelProvider := ""
+	var providers []string
+
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			if name, ok := strings.CutPrefix(section, "model_providers."); ok {
+				name = strings.Trim(strings.TrimSpace(name), `"'`)
+				if name != "" {
+					providers = append(providers, name)
+				}
+			}
+			continue
+		}
+		if section != "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if ok && strings.TrimSpace(key) == "model_provider" {
+			topLevelProvider = strings.Trim(strings.TrimSpace(value), `"'`)
+		}
+	}
+
+	if topLevelProvider != "" {
+		// Codex already honors a correctly-placed selection; don't override it.
+		return ""
+	}
+	if len(providers) == 1 {
+		return providers[0]
+	}
+	return ""
+}

--- a/pkg/engine/codex_test.go
+++ b/pkg/engine/codex_test.go
@@ -1,0 +1,121 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseCodexForcedProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "misordered selection nested under history table",
+			content: `[history]
+persistence = "none"
+
+model_provider = "openai-proxy"
+
+[model_providers.openai-proxy]
+name = "OpenAI AWF proxy"
+base_url = "http://172.30.0.30:10000"
+env_key = "OPENAI_API_KEY"
+`,
+			want: "openai-proxy",
+		},
+		{
+			name: "correct top-level selection is respected (no override)",
+			content: `model_provider = "openai-proxy"
+
+[model_providers.openai-proxy]
+base_url = "http://172.30.0.30:10000"
+
+[history]
+persistence = "none"
+`,
+			want: "",
+		},
+		{
+			name: "provider table without any selection",
+			content: `[history]
+persistence = "none"
+
+[model_providers.openai-proxy]
+base_url = "http://172.30.0.30:10000"
+`,
+			want: "openai-proxy",
+		},
+		{
+			name: "no custom provider defined",
+			content: `[history]
+persistence = "none"
+`,
+			want: "",
+		},
+		{
+			name: "ambiguous multiple providers",
+			content: `[model_providers.one]
+base_url = "http://one"
+
+[model_providers.two]
+base_url = "http://two"
+`,
+			want: "",
+		},
+		{
+			name: "comments are ignored",
+			content: `# model_provider = "commented-out"
+[history]
+persistence = "none"
+# [model_providers.ignored]
+[model_providers.real]
+base_url = "http://real"
+`,
+			want: "real",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseCodexForcedProvider(tt.content); got != tt.want {
+				t.Fatalf("parseCodexForcedProvider() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexForcedProviderReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	content := `[history]
+persistence = "none"
+
+model_provider = "openai-proxy"
+
+[model_providers.openai-proxy]
+base_url = "http://172.30.0.30:10000"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	if got := codexForcedProvider(configPath); got != "openai-proxy" {
+		t.Fatalf("codexForcedProvider() = %q, want %q", got, "openai-proxy")
+	}
+
+	if got := codexForcedProvider(filepath.Join(dir, "missing.toml")); got != "" {
+		t.Fatalf("codexForcedProvider(missing) = %q, want empty", got)
+	}
+	if got := codexForcedProvider(""); got != "" {
+		t.Fatalf("codexForcedProvider(empty path) = %q, want empty", got)
+	}
+}
+
+func TestCodexConfigPathHonorsCodexHome(t *testing.T) {
+	t.Setenv("CODEX_HOME", "/tmp/example-codex-home")
+	if got, want := codexConfigPath(), filepath.Join("/tmp/example-codex-home", "config.toml"); got != want {
+		t.Fatalf("codexConfigPath() = %q, want %q", got, want)
+	}
+}

--- a/pkg/engine/codex_test.go
+++ b/pkg/engine/codex_test.go
@@ -119,3 +119,62 @@ func TestCodexConfigPathHonorsCodexHome(t *testing.T) {
 		t.Fatalf("codexConfigPath() = %q, want %q", got, want)
 	}
 }
+
+func TestResolveModel(t *testing.T) {
+	// Ensure a clean slate for all detection-model env vars.
+	for _, name := range []string{
+		"GH_AW_MODEL_DETECTION_COPILOT",
+		"GH_AW_MODEL_DETECTION_CLAUDE",
+		"GH_AW_MODEL_DETECTION_CODEX",
+	} {
+		t.Setenv(name, "")
+	}
+
+	t.Run("explicit flag always wins", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_CODEX", "gpt-5.4")
+		if got := ResolveModel("codex", "gpt-flag"); got != "gpt-flag" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "gpt-flag")
+		}
+	})
+
+	t.Run("codex falls back to env", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_CODEX", "gpt-5.4")
+		if got := ResolveModel("codex", ""); got != "gpt-5.4" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "gpt-5.4")
+		}
+	})
+
+	t.Run("claude falls back to env", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_CLAUDE", "claude-sonnet-4.6")
+		if got := ResolveModel("claude", ""); got != "claude-sonnet-4.6" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "claude-sonnet-4.6")
+		}
+	})
+
+	t.Run("copilot falls back to env", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_COPILOT", "some-copilot-model")
+		if got := ResolveModel("copilot", ""); got != "some-copilot-model" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "some-copilot-model")
+		}
+	})
+
+	t.Run("empty engine uses default copilot env", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_COPILOT", "default-engine-model")
+		if got := ResolveModel("", ""); got != "default-engine-model" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "default-engine-model")
+		}
+	})
+
+	t.Run("no flag and no env yields empty", func(t *testing.T) {
+		if got := ResolveModel("codex", ""); got != "" {
+			t.Fatalf("ResolveModel() = %q, want empty", got)
+		}
+	})
+
+	t.Run("env value is trimmed", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_CODEX", "  gpt-5.4  ")
+		if got := ResolveModel("codex", ""); got != "gpt-5.4" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "gpt-5.4")
+		}
+	})
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -42,6 +42,19 @@ func Canonical(engineID string) string {
 	return strings.ToLower(engineID)
 }
 
+// ResolveModel returns the model to use for detection. An explicit flagModel
+// always wins. Otherwise it falls back to the engine-specific detection model
+// environment variable set by gh-aw (GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}),
+// so the standalone detector honors the same model the caller configured for the
+// base (harness-driven) detection path.
+func ResolveModel(engineID, flagModel string) string {
+	if flagModel != "" {
+		return flagModel
+	}
+	envName := "GH_AW_MODEL_DETECTION_" + strings.ToUpper(Canonical(engineID))
+	return strings.TrimSpace(os.Getenv(envName))
+}
+
 // New creates a new engine instance based on the engine ID.
 // If engineID is empty, it defaults to "copilot".
 func New(engineID, model string) (Engine, error) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -107,7 +107,8 @@ func (e *codexEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeOp
 		return "", err
 	}
 	defer cleanup()
-	return runCLIEnvWithSink(ctx, "codex", codexArgs(e.model, ""), prompt, toolEnv, opts.ResultSinkPath)
+	provider := codexForcedProvider(codexConfigPath())
+	return runCLIEnvWithSink(ctx, "codex", codexArgs(e.model, provider, ""), prompt, toolEnv, opts.ResultSinkPath)
 }
 
 // maybeProvisionResultTool provisions the threat_detection_result tool when a
@@ -189,7 +190,7 @@ func claudeArgs(model string, allowBash bool) []string {
 	return append(args, "-")
 }
 
-func codexArgs(model, prompt string) []string {
+func codexArgs(model, provider, prompt string) []string {
 	args := []string{
 		"exec",
 		"-c", "web_search=disabled",
@@ -198,6 +199,9 @@ func codexArgs(model, prompt string) []string {
 		"--skip-git-repo-check",
 		"--",
 		prompt,
+	}
+	if provider != "" {
+		args = append([]string{"-c", "model_provider=" + provider}, args...)
 	}
 	if model != "" {
 		args = append([]string{"-c", "model=" + model}, args...)

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -199,7 +199,7 @@ func TestEngineCommandArgs(t *testing.T) {
 	})
 
 	t.Run("codex", func(t *testing.T) {
-		got := codexArgs("gpt-5-codex", "detect threats")
+		got := codexArgs("gpt-5-codex", "", "detect threats")
 		want := []string{
 			"-c", "model=gpt-5-codex",
 			"exec",
@@ -216,8 +216,26 @@ func TestEngineCommandArgs(t *testing.T) {
 	})
 
 	t.Run("codex default model", func(t *testing.T) {
-		got := codexArgs("", "detect threats")
+		got := codexArgs("", "", "detect threats")
 		want := []string{
+			"exec",
+			"-c", "web_search=disabled",
+			"-c", "fetch=disabled",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--skip-git-repo-check",
+			"--",
+			"detect threats",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("codexArgs() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("codex with forced provider", func(t *testing.T) {
+		got := codexArgs("gpt-5-codex", "openai-proxy", "detect threats")
+		want := []string{
+			"-c", "model=gpt-5-codex",
+			"-c", "model_provider=openai-proxy",
 			"exec",
 			"-c", "web_search=disabled",
 			"-c", "fetch=disabled",


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KY2YG1DG87H41RDW5YCK5V0K)

## Summary

Fixes the failing **Smoke Codex Standalone** workflow (401 `invalid_api_key` from `api.openai.com`) and aligns standalone detection model selection with the base (harness-driven) path for all three engines.

## Root cause

In the standalone Codex detection path, gh-aw generates a `config.toml` where `model_provider` is emitted **after** the `[history]` table:

```toml
[history]
persistence = "none"

model_provider = "openai-proxy"     # binds to [history], not top-level
[model_providers.openai-proxy]
...
```

In TOML, `model_provider` binds to the currently-open `[history]` table (`history.model_provider`), which Codex treats as an unknown key and silently drops. Codex then falls back to the default `openai` provider and connects directly to `api.openai.com` with the AWF placeholder key `sk-placeholder-proxy` → **401**. The base smoke works because its config generation reorders `model_provider` to the top level.

## Changes

**1. Force the codex provider on the CLI (`fix`)**
- `codexArgs` now emits `-c model_provider=<name>`, which wins regardless of TOML placement (verified against codex 0.144.5).
- `parseCodexForcedProvider` only forces a provider when there is **no** valid top-level `model_provider` **and** exactly one `[model_providers.*]` table exists — so correctly-configured setups are untouched and ambiguous ones are left alone.
- Pure stdlib line scanner (module has no TOML dependency).

**2. Honor `GH_AW_MODEL_DETECTION_*` (`feat`)**
- The standalone detector ran `threat-detect --engine <e>` with no `--model`, so codex/claude silently used the CLI default model. Added `engine.ResolveModel`: when `--model` is unset it falls back to `GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}`.
- Threaded into each engine: codex → `-c model=<m>`, claude → `--model <m>`, copilot → `COPILOT_MODEL`.
- Copilot standalone sets `COPILOT_MODEL` directly (not `GH_AW_MODEL_DETECTION_COPILOT`); `copilotEnv` only sets `COPILOT_MODEL` when a model is resolved, so the inherited value passes through untouched (no regression).

## Testing

- New tests: `parseCodexForcedProvider`, `codexForcedProvider`, `codexConfigPath` (CODEX_HOME), `ResolveModel` (flag precedence, per-engine env fallback, defaults, trimming); updated `codexArgs` subtests for the 3-arg signature + a forced-provider case.
- `make fmt-check lint build test` all pass (118 tests, 0 failures).

## Note

The smoke downloads the **released** `threat-detect` binary pinned by the gh-aw compiler, so these source fixes take effect once a new release is cut and the standalone lock recompiled. The underlying config-ordering bug should ideally also be fixed upstream in the gh-aw compiler.