### PR TITLE
feat(smoke): add opt-in latest-prerelease detector smoke workflow

### DIFF
--- a/.github/workflows/smoke-standalone-latest.yml
+++ b/.github/workflows/smoke-standalone-latest.yml
@@ -1,0 +1,218 @@
+name: Smoke Standalone Latest
+
+# Opt-in smoke test that exercises the released `threat-detect` binary at a
+# NON-DEFAULT tag (by default the newest prerelease) against each engine.
+#
+# The scheduled `*-standalone` smoke workflows deliberately pin a specific
+# promoted tag at compile time for reproducibility. This workflow provides the
+# complementary "release candidate" path: point it at a freshly tagged
+# prerelease, confirm the binary produces a verdict with every engine, then
+# promote the release. It never runs on a schedule and never changes the
+# steady-state behaviour of the pinned smokes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      detector_tag:
+        description: >-
+          Detector release tag to test (e.g. v0.3.0-rc.1). Leave empty to
+          resolve the newest prerelease automatically.
+        required: false
+        default: ''
+        type: string
+      engine:
+        description: Which engine(s) to smoke test.
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - copilot
+          - claude
+          - codex
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      detector_tag: ${{ steps.tag.outputs.detector_tag }}
+      is_prerelease: ${{ steps.tag.outputs.is_prerelease }}
+      engines: ${{ steps.engines.outputs.engines }}
+    steps:
+      - name: Resolve detector tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || github.token }}
+          REPO: github/gh-aw-threat-detection
+          INPUT_TAG: ${{ inputs.detector_tag }}
+          VAR_TAG: ${{ vars.GH_AW_THREAT_DETECTION_VERSION }}
+        run: |
+          set -euo pipefail
+          # Precedence: workflow_dispatch input > repo variable > newest prerelease.
+          tag="${INPUT_TAG:-}"
+          source="workflow_dispatch input"
+          if [ -z "$tag" ]; then
+            tag="${VAR_TAG:-}"
+            source="GH_AW_THREAT_DETECTION_VERSION variable"
+          fi
+          if [ -z "$tag" ]; then
+            tag="$(gh release list --repo "$REPO" --exclude-drafts --limit 50 \
+              --json tagName,isPrerelease,publishedAt \
+              --jq 'map(select(.isPrerelease)) | sort_by(.publishedAt) | last | .tagName')"
+            source="newest prerelease"
+          fi
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "::error::Could not resolve a detector tag to test. Provide 'detector_tag' or publish a prerelease."
+            exit 1
+          fi
+          is_pre="$(gh release view "$tag" --repo "$REPO" --json isPrerelease --jq '.isPrerelease' 2>/dev/null || echo unknown)"
+          echo "detector_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$is_pre" >> "$GITHUB_OUTPUT"
+          echo "Resolved detector tag '$tag' (source: $source, prerelease: $is_pre)"
+          {
+            echo "### Detector tag under test"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Tag | \`$tag\` |"
+            echo "| Source | $source |"
+            echo "| Prerelease | $is_pre |"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Select engines
+        id: engines
+        env:
+          ENGINE: ${{ inputs.engine }}
+        run: |
+          set -euo pipefail
+          case "${ENGINE:-all}" in
+            all|'') echo 'engines=["copilot","claude","codex"]' >> "$GITHUB_OUTPUT" ;;
+            copilot|claude|codex) echo "engines=[\"${ENGINE}\"]" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Unknown engine '${ENGINE}'"; exit 1 ;;
+          esac
+
+  smoke:
+    needs: resolve
+    runs-on: ubuntu-latest
+    name: smoke (${{ matrix.engine }})
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: ${{ fromJSON(needs.resolve.outputs.engines) }}
+    env:
+      DETECTOR_TAG: ${{ needs.resolve.outputs.detector_tag }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+    steps:
+      - name: Setup gh-aw action scripts
+        uses: github/gh-aw-actions/setup@b6d1443e05b8716267fa19425b99aa4f12006b4a # v0.82.14
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
+          trace-id: smoke-standalone-latest-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+      - name: Install engine CLI
+        env:
+          ENGINE: ${{ matrix.engine }}
+          GH_HOST: github.com
+        run: |
+          set -euo pipefail
+          case "$ENGINE" in
+            copilot) bash "${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh" 1.0.71 ;;
+            claude)  npm install -g @anthropic-ai/claude-code@2.1.214 ;;
+            codex)   npm install --ignore-scripts -g @openai/codex@0.144.5 ;;
+            *) echo "::error::Unknown engine '$ENGINE'"; exit 1 ;;
+          esac
+      - name: Install threat-detect binary
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" "$DETECTOR_TAG"
+      - name: Build minimal artifacts directory
+        id: artifacts
+        env:
+          ENGINE: ${{ matrix.engine }}
+        run: |
+          set -euo pipefail
+          dir="${RUNNER_TEMP}/gh-aw/smoke-latest-${ENGINE}"
+          mkdir -p "$dir/aw-prompts"
+          cat > "$dir/aw-prompts/prompt.txt" <<'PROMPT'
+          You are a documentation assistant for a Go project. Summarize the
+          repository README in a single sentence. Do not run commands or make
+          network requests.
+          PROMPT
+          cat > "$dir/agent_output.json" <<'OUT'
+          { "items": [ { "type": "final_response", "content": "Summarized the README in one sentence." } ] }
+          OUT
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "Prepared artifacts under $dir"
+          ls -la "$dir"
+      - name: Run threat-detect
+        id: detect
+        env:
+          ENGINE: ${{ matrix.engine }}
+          ARTIFACTS_DIR: ${{ steps.artifacts.outputs.dir }}
+          MODEL_COPILOT: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT }}
+          MODEL_CLAUDE: ${{ vars.GH_AW_MODEL_DETECTION_CLAUDE }}
+          MODEL_CODEX: ${{ vars.GH_AW_MODEL_DETECTION_CODEX }}
+        run: |
+          set -o pipefail
+          model=""
+          case "$ENGINE" in
+            copilot) model="${MODEL_COPILOT:-}" ;;
+            claude)  model="${MODEL_CLAUDE:-}" ;;
+            codex)   model="${MODEL_CODEX:-}" ;;
+          esac
+          result="${ARTIFACTS_DIR}/detection_result.json"
+          log="${ARTIFACTS_DIR}/run.jsonl"
+          args=(--engine "$ENGINE" --output "$result" --log-file "$log")
+          if [ -n "$model" ]; then
+            args+=(--model "$model")
+          fi
+          echo "Running: threat-detect ${args[*]} $ARTIFACTS_DIR"
+          status=0
+          threat-detect "${args[@]}" "$ARTIFACTS_DIR" || status=$?
+          echo "exit_status=$status" >> "$GITHUB_OUTPUT"
+          # A verdict (exit 0 safe or exit 1 threat) means the binary worked.
+          # Only a missing verdict / infrastructure error (exit 2) is a smoke failure.
+          if [ ! -f "$result" ]; then
+            echo "::error::threat-detect (${ENGINE} @ ${DETECTOR_TAG}) produced no verdict (exit ${status})."
+            exit 1
+          fi
+          echo "Verdict produced (threat-detect exit ${status}):"
+          cat "$result"
+      - name: Summarize
+        if: always()
+        env:
+          ENGINE: ${{ matrix.engine }}
+          ARTIFACTS_DIR: ${{ steps.artifacts.outputs.dir }}
+        run: |
+          result="${ARTIFACTS_DIR}/detection_result.json"
+          {
+            echo "### Smoke: ${ENGINE} @ \`${DETECTOR_TAG}\`"
+            echo ""
+            if [ -f "$result" ]; then
+              echo "Result: ✅ verdict produced"
+              echo ""
+              echo '```json'
+              cat "$result"
+              echo ""
+              echo '```'
+            else
+              echo "Result: ❌ no verdict produced"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload detection artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: smoke-standalone-latest-${{ matrix.engine }}
+          path: |
+            ${{ steps.artifacts.outputs.dir }}/detection_result.json
+            ${{ steps.artifacts.outputs.dir }}/run.jsonl
+          if-no-files-found: ignore

--- a/.github/workflows/smoke-standalone-latest.yml
+++ b/.github/workflows/smoke-standalone-latest.yml
@@ -1,22 +1,29 @@
 name: Smoke Standalone Latest
 
-# Opt-in smoke test that exercises the released `threat-detect` binary at a
-# NON-DEFAULT tag (by default the newest prerelease) against each engine.
+# Smoke test that exercises the released `threat-detect` binary at a
+# NON-DEFAULT tag (a release candidate) against each engine.
 #
 # The scheduled `*-standalone` smoke workflows deliberately pin a specific
-# promoted tag at compile time for reproducibility. This workflow provides the
-# complementary "release candidate" path: point it at a freshly tagged
-# prerelease, confirm the binary produces a verdict with every engine, then
-# promote the release. It never runs on a schedule and never changes the
-# steady-state behaviour of the pinned smokes.
+# promoted tag at compile time for reproducibility. This workflow is the
+# complementary "release candidate" path: it validates a freshly published
+# prerelease end-to-end so it can be promoted with confidence. It never
+# changes the steady-state behaviour of the pinned smokes.
+#
+# Triggers:
+#   * workflow_dispatch — manual, with optional tag / engine overrides.
+#   * workflow_run       — automatically after the "Release" workflow finishes
+#                          publishing a new (pre)release. (The Release workflow
+#                          creates the release with GITHUB_TOKEN, so a plain
+#                          `on: release` trigger would never fire.)
 
 on:
   workflow_dispatch:
     inputs:
       detector_tag:
         description: >-
-          Detector release tag to test (e.g. v0.3.0-rc.1). Leave empty to
-          resolve the newest prerelease automatically.
+          Detector release tag to test (e.g. v0.3.0-rc.1). Leave empty to fall
+          back, in order, to the GH_AW_THREAT_DETECTION_VERSION repository
+          variable and then the newest prerelease.
         required: false
         default: ''
         type: string
@@ -30,6 +37,10 @@ on:
           - copilot
           - claude
           - codex
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -37,6 +48,9 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # For workflow_run triggers, only proceed when the Release workflow succeeded.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       detector_tag: ${{ steps.tag.outputs.detector_tag }}
       is_prerelease: ${{ steps.tag.outputs.is_prerelease }}
@@ -47,22 +61,45 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || github.token }}
           REPO: github/gh-aw-threat-detection
+          EVENT: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.detector_tag }}
           VAR_TAG: ${{ vars.GH_AW_THREAT_DETECTION_VERSION }}
+          # Tag of the release whose Release workflow just completed (auto-run).
+          # Tag pushes often leave head_branch null, so this may be empty.
+          RELEASE_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
         run: |
           set -euo pipefail
-          # Precedence: workflow_dispatch input > repo variable > newest prerelease.
-          tag="${INPUT_TAG:-}"
-          source="workflow_dispatch input"
-          if [ -z "$tag" ]; then
-            tag="${VAR_TAG:-}"
-            source="GH_AW_THREAT_DETECTION_VERSION variable"
-          fi
-          if [ -z "$tag" ]; then
-            tag="$(gh release list --repo "$REPO" --exclude-drafts --limit 50 \
+          newest_prerelease() {
+            gh release list --repo "$REPO" --exclude-drafts --limit 50 \
               --json tagName,isPrerelease,publishedAt \
-              --jq 'map(select(.isPrerelease)) | sort_by(.publishedAt) | last | .tagName')"
-            source="newest prerelease"
+              --jq 'map(select(.isPrerelease)) | sort_by(.publishedAt) | last | .tagName'
+          }
+          tag=""
+          source=""
+          if [ "$EVENT" = "workflow_run" ]; then
+            # Auto-run: always test the release that just published. Prefer the
+            # triggering tag; fall back to the newest prerelease when the event
+            # payload omits it. The pinned override variable is ignored here so
+            # auto-runs deterministically exercise the new binary.
+            if [ -n "${RELEASE_TAG:-}" ]; then
+              tag="$RELEASE_TAG"
+              source="triggering Release run"
+            else
+              tag="$(newest_prerelease)"
+              source="newest prerelease (auto-run)"
+            fi
+          else
+            # Manual run precedence: input > repository variable > newest prerelease.
+            if [ -n "${INPUT_TAG:-}" ]; then
+              tag="$INPUT_TAG"
+              source="workflow_dispatch input"
+            elif [ -n "${VAR_TAG:-}" ]; then
+              tag="$VAR_TAG"
+              source="GH_AW_THREAT_DETECTION_VERSION variable"
+            else
+              tag="$(newest_prerelease)"
+              source="newest prerelease"
+            fi
           fi
           if [ -z "$tag" ] || [ "$tag" = "null" ]; then
             echo "::error::Could not resolve a detector tag to test. Provide 'detector_tag' or publish a prerelease."
@@ -80,11 +117,13 @@ jobs:
             echo "| Tag | \`$tag\` |"
             echo "| Source | $source |"
             echo "| Prerelease | $is_pre |"
+            echo "| Trigger | ${{ github.event_name }} |"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Select engines
         id: engines
         env:
-          ENGINE: ${{ inputs.engine }}
+          # Auto-runs (workflow_run) always cover every engine.
+          ENGINE: ${{ github.event_name == 'workflow_dispatch' && inputs.engine || 'all' }}
         run: |
           set -euo pipefail
           case "${ENGINE:-all}" in
@@ -97,16 +136,13 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     name: smoke (${{ matrix.engine }})
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         engine: ${{ fromJSON(needs.resolve.outputs.engines) }}
     env:
       DETECTOR_TAG: ${{ needs.resolve.outputs.detector_tag }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
     steps:
       - name: Setup gh-aw action scripts
         uses: github/gh-aw-actions/setup@b6d1443e05b8716267fa19425b99aa4f12006b4a # v0.82.14
@@ -154,9 +190,16 @@ jobs:
           ls -la "$dir"
       - name: Run threat-detect
         id: detect
+        # Provider credentials are scoped to this step only, and only the
+        # secret for the engine under test is populated — so the setup action
+        # and npm install scripts in earlier steps never receive them.
         env:
           ENGINE: ${{ matrix.engine }}
           ARTIFACTS_DIR: ${{ steps.artifacts.outputs.dir }}
+          COPILOT_GITHUB_TOKEN: ${{ matrix.engine == 'copilot' && secrets.COPILOT_GITHUB_TOKEN || '' }}
+          ANTHROPIC_API_KEY: ${{ matrix.engine == 'claude' && secrets.ANTHROPIC_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ matrix.engine == 'codex' && secrets.OPENAI_API_KEY || '' }}
+          CODEX_API_KEY: ${{ matrix.engine == 'codex' && secrets.CODEX_API_KEY || '' }}
           MODEL_COPILOT: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT }}
           MODEL_CLAUDE: ${{ vars.GH_AW_MODEL_DETECTION_CLAUDE }}
           MODEL_CODEX: ${{ vars.GH_AW_MODEL_DETECTION_CODEX }}
@@ -178,33 +221,56 @@ jobs:
           status=0
           threat-detect "${args[@]}" "$ARTIFACTS_DIR" || status=$?
           echo "exit_status=$status" >> "$GITHUB_OUTPUT"
-          # A verdict (exit 0 safe or exit 1 threat) means the binary worked.
-          # Only a missing verdict / infrastructure error (exit 2) is a smoke failure.
-          if [ ! -f "$result" ]; then
-            echo "::error::threat-detect (${ENGINE} @ ${DETECTOR_TAG}) produced no verdict (exit ${status})."
+          # Exit-code contract: 0 = safe, 1 = threat detected, 2 = infra error.
+          # A healthy candidate MUST exit 0 or 1 AND emit a well-formed verdict.
+          if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
+            echo "::error::threat-detect (${ENGINE} @ ${DETECTOR_TAG}) exited ${status} (infrastructure error)."
             exit 1
           fi
-          echo "Verdict produced (threat-detect exit ${status}):"
-          cat "$result"
+          if [ ! -f "$result" ]; then
+            echo "::error::threat-detect (${ENGINE} @ ${DETECTOR_TAG}) produced no verdict file."
+            exit 1
+          fi
+          if ! jq -e '
+              type == "object"
+              and (.prompt_injection | type == "boolean")
+              and (.secret_leak      | type == "boolean")
+              and (.malicious_patch  | type == "boolean")
+              and (.reasons          | type == "array")
+            ' "$result" >/dev/null 2>&1; then
+            echo "::error::threat-detect (${ENGINE} @ ${DETECTOR_TAG}) produced a malformed verdict:"
+            cat "$result" || true
+            exit 1
+          fi
+          echo "Valid verdict produced (threat-detect exit ${status}):"
+          jq . "$result"
       - name: Summarize
         if: always()
         env:
           ENGINE: ${{ matrix.engine }}
           ARTIFACTS_DIR: ${{ steps.artifacts.outputs.dir }}
+          STATUS: ${{ steps.detect.outcome }}
         run: |
           result="${ARTIFACTS_DIR}/detection_result.json"
           {
             echo "### Smoke: ${ENGINE} @ \`${DETECTOR_TAG}\`"
             echo ""
-            if [ -f "$result" ]; then
-              echo "Result: ✅ verdict produced"
+            if [ "${STATUS}" = "success" ] && [ -f "$result" ]; then
+              echo "Result: ✅ valid verdict produced"
               echo ""
               echo '```json'
               cat "$result"
               echo ""
               echo '```'
             else
-              echo "Result: ❌ no verdict produced"
+              echo "Result: ❌ smoke failed (step outcome: ${STATUS})"
+              if [ -f "$result" ]; then
+                echo ""
+                echo '```json'
+                cat "$result"
+                echo ""
+                echo '```'
+              fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload detection artifacts

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,6 +2,22 @@ name: Smoke
 
 on:
   workflow_dispatch:
+    inputs:
+      include_latest:
+        description: >-
+          Also dispatch smoke-standalone-latest.yml, which tests a non-default
+          detector tag (newest prerelease by default). Leave off for the
+          reproducible, pinned smokes only.
+        required: false
+        default: false
+        type: boolean
+      detector_tag:
+        description: >-
+          Detector tag forwarded to smoke-standalone-latest.yml when
+          include_latest is enabled. Empty resolves the newest prerelease.
+        required: false
+        default: ''
+        type: string
 
 permissions:
   actions: write
@@ -43,3 +59,18 @@ jobs:
             printf '  %s\n' "${failures[@]}" >&2
             exit 1
           fi
+      - name: Dispatch latest-prerelease smoke
+        if: ${{ inputs.include_latest }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref_name }}
+          DETECTOR_TAG: ${{ inputs.detector_tag }}
+        run: |
+          set -euo pipefail
+          args=(smoke-standalone-latest.yml --repo "$REPO" --ref "$REF")
+          if [ -n "${DETECTOR_TAG:-}" ]; then
+            args+=(--field "detector_tag=${DETECTOR_TAG}")
+          fi
+          gh workflow run "${args[@]}"
+          echo "Dispatched smoke-standalone-latest.yml (detector_tag='${DETECTOR_TAG:-<newest prerelease>}')"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,8 @@ on:
       detector_tag:
         description: >-
           Detector tag forwarded to smoke-standalone-latest.yml when
-          include_latest is enabled. Empty resolves the newest prerelease.
+          include_latest is enabled. If empty, that workflow falls back to the
+          GH_AW_THREAT_DETECTION_VERSION variable, then the newest prerelease.
         required: false
         default: ''
         type: string
@@ -73,4 +74,8 @@ jobs:
             args+=(--field "detector_tag=${DETECTOR_TAG}")
           fi
           gh workflow run "${args[@]}"
-          echo "Dispatched smoke-standalone-latest.yml (detector_tag='${DETECTOR_TAG:-<newest prerelease>}')"
+          if [ -n "${DETECTOR_TAG:-}" ]; then
+            echo "Dispatched smoke-standalone-latest.yml (detector_tag='${DETECTOR_TAG}')"
+          else
+            echo "Dispatched smoke-standalone-latest.yml (detector_tag empty; child resolves GH_AW_THREAT_DETECTION_VERSION, else newest prerelease)"
+          fi

--- a/README.md
+++ b/README.md
@@ -304,7 +304,32 @@ Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can b
 
 `.github/workflows/detection-only.yml` is a manual iteration workflow for the generated detection job. It keeps the copied detection job body aligned with the `smoke-copilot-standalone` smoke workflow, while replacing prior activation and agent jobs with stubs that upload local fixtures from `testdata/detection-only/` as the `agent` artifact.
 
-Recompile the smoke workflows with `gh aw compile` after editing their `.md` sources.
+### Testing a Release Candidate (`smoke-standalone-latest.yml`)
+
+`.github/workflows/smoke-standalone-latest.yml` is an **opt-in** workflow that runs the released `threat-detect` binary at a **non-default tag** — by default the newest prerelease — against each engine. It exists so a freshly tagged prerelease can be validated end-to-end before it is promoted to **Latest**, without disturbing the reproducible, compile-time pin used by the scheduled `*-standalone` smokes.
+
+It never runs on a schedule, so steady-state behaviour is unchanged. On dispatch it:
+
+1. Resolves the detector tag with this precedence, logging the choice to the run summary:
+   1. the `detector_tag` `workflow_dispatch` input, if provided;
+   2. the `GH_AW_THREAT_DETECTION_VERSION` repository variable, if set;
+   3. otherwise the newest **prerelease** (`gh release list --json ... isPrerelease`).
+2. For each selected engine (`all` by default, or a single engine), installs the engine CLI, installs the resolved `threat-detect` tag via the checksum-verifying `install_threat_detect_binary.sh`, and runs a detection over a minimal benign artifacts directory.
+3. Passes the job when the binary produces a verdict (`detection_result.json`) — a `safe` (exit 0) or `threat` (exit 1) result both count as a working binary; only a missing verdict / infrastructure error (exit 2) fails the smoke.
+
+**Tag → test → promote loop:**
+
+1. Cut a release tag (`create-release-tag.yml`); `release.yml` publishes a version-tagged **prerelease** with the recorded asset sha256.
+2. Run **Smoke Standalone Latest** (`workflow_dispatch`). Leave `detector_tag` empty to pick up the prerelease you just published, or pin an explicit tag. Optionally scope to a single engine.
+3. Confirm every engine job is green and the run summary shows the expected tag.
+4. Promote with `promote-release.yml`; it re-verifies the asset sha256 and marks the release **Latest** (stable). The pinned `*-standalone` smokes continue to run against the promoted tag.
+
+You can also start it from the top-level **Smoke** workflow by dispatching it with `include_latest: true` (and an optional `detector_tag`); the default pinned smokes still dispatch unchanged.
+
+> [!NOTE]
+> This workflow runs the detector binary directly on the runner to keep it self-contained and free of AWF image/version drift. The firewall (AWF) execution path is continuously validated by the scheduled `*-standalone` smokes against the promoted release.
+
+Recompile the smoke workflows with `gh aw compile` after editing their `.md` sources. `smoke-standalone-latest.yml` is a hand-authored workflow (not compiled from a `.md`).
 
 | Secret | Required for | Notes |
 |--------|--------------|-------|
@@ -320,7 +345,7 @@ Optional Actions variables:
 |----------|---------|
 | `GH_AW_MODEL_AGENT_COPILOT`, `GH_AW_MODEL_AGENT_CLAUDE`, `GH_AW_MODEL_AGENT_CODEX` | Override the agent model for each smoke workflow. |
 | `GH_AW_MODEL_DETECTION_COPILOT`, `GH_AW_MODEL_DETECTION_CLAUDE`, `GH_AW_MODEL_DETECTION_CODEX` | Override the detection model for each engine. |
-| `GH_AW_THREAT_DETECTION_VERSION` | Detector release tag downloaded by `detection-only.yml` (defaults to the latest promoted release when unset). The `*-standalone` smoke workflows instead pin a specific promoted tag at compile time for reproducibility. |
+| `GH_AW_THREAT_DETECTION_VERSION` | Detector release tag downloaded by `detection-only.yml`, and the default override tag for `smoke-standalone-latest.yml` when its `detector_tag` input is empty (defaults to the latest promoted release for `detection-only.yml`, or the newest prerelease for `smoke-standalone-latest.yml`, when unset). The scheduled `*-standalone` smoke workflows instead pin a specific promoted tag at compile time for reproducibility. |
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -306,21 +306,25 @@ Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can b
 
 ### Testing a Release Candidate (`smoke-standalone-latest.yml`)
 
-`.github/workflows/smoke-standalone-latest.yml` is an **opt-in** workflow that runs the released `threat-detect` binary at a **non-default tag** — by default the newest prerelease — against each engine. It exists so a freshly tagged prerelease can be validated end-to-end before it is promoted to **Latest**, without disturbing the reproducible, compile-time pin used by the scheduled `*-standalone` smokes.
+`.github/workflows/smoke-standalone-latest.yml` runs the released `threat-detect` binary at a **non-default tag** — a release candidate — against each engine. It exists so a freshly published prerelease can be validated end-to-end before it is promoted to **Latest**, without disturbing the reproducible, compile-time pin used by the scheduled `*-standalone` smokes.
 
-It never runs on a schedule, so steady-state behaviour is unchanged. On dispatch it:
+It runs in two ways:
 
-1. Resolves the detector tag with this precedence, logging the choice to the run summary:
-   1. the `detector_tag` `workflow_dispatch` input, if provided;
-   2. the `GH_AW_THREAT_DETECTION_VERSION` repository variable, if set;
-   3. otherwise the newest **prerelease** (`gh release list --json ... isPrerelease`).
-2. For each selected engine (`all` by default, or a single engine), installs the engine CLI, installs the resolved `threat-detect` tag via the checksum-verifying `install_threat_detect_binary.sh`, and runs a detection over a minimal benign artifacts directory.
-3. Passes the job when the binary produces a verdict (`detection_result.json`) — a `safe` (exit 0) or `threat` (exit 1) result both count as a working binary; only a missing verdict / infrastructure error (exit 2) fails the smoke.
+- **Automatically** after the **Release** workflow finishes publishing a new (pre)release (`workflow_run`). The Release workflow creates the release with `GITHUB_TOKEN`, so a plain `on: release` trigger would never fire — hence the `workflow_run` hook. Auto-runs test the just-published tag across all three engines.
+- **Manually** via `workflow_dispatch`, with optional `detector_tag` and `engine` inputs.
+
+It never runs on a schedule, so steady-state behaviour is unchanged. On each run it:
+
+1. Resolves the detector tag and logs the choice (and trigger) to the run summary:
+   - **Auto-runs** test the release that just published: the triggering **Release** tag, or the newest **prerelease** when the event omits it. The pinned override variable is intentionally ignored so auto-runs always exercise the new binary.
+   - **Manual runs** use this precedence: the `detector_tag` input → the `GH_AW_THREAT_DETECTION_VERSION` repository variable → the newest **prerelease** (`gh release list --json ... isPrerelease`).
+2. For each selected engine (`all` on auto-runs; `all` or a single engine on manual runs) installs the engine CLI, installs the resolved `threat-detect` tag via the checksum-verifying `install_threat_detect_binary.sh`, and runs a detection over a minimal benign artifacts directory. Each engine runs as an independent matrix job (`fail-fast: false`), and the job has a 30-minute timeout.
+3. Passes only when the binary exits `0` (safe) or `1` (threat) **and** emits a well-formed verdict JSON (`prompt_injection`, `secret_leak`, `malicious_patch` booleans plus a `reasons` array). An infrastructure error (exit `2`), a missing verdict, or malformed JSON fails the smoke.
 
 **Tag → test → promote loop:**
 
-1. Cut a release tag (`create-release-tag.yml`); `release.yml` publishes a version-tagged **prerelease** with the recorded asset sha256.
-2. Run **Smoke Standalone Latest** (`workflow_dispatch`). Leave `detector_tag` empty to pick up the prerelease you just published, or pin an explicit tag. Optionally scope to a single engine.
+1. Cut a release tag (`create-release-tag.yml`); `release.yml` publishes a version-tagged **prerelease** with the recorded asset sha256. **Smoke Standalone Latest** then starts automatically against that tag.
+2. To re-run or pin an explicit tag manually, dispatch **Smoke Standalone Latest** (`workflow_dispatch`) with a `detector_tag` (or leave it empty). Optionally scope to a single engine.
 3. Confirm every engine job is green and the run summary shows the expected tag.
 4. Promote with `promote-release.yml`; it re-verifies the asset sha256 and marks the release **Latest** (stable). The pinned `*-standalone` smokes continue to run against the promoted tag.
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KY30QSCMD09FNCX54JRV4ET8)

## Summary

Closes #583.

Adds an **opt-in** way to point the smoke tests at a non-default detector tag (e.g. the newest prerelease) **without** disturbing the reproducible compile-time pin used by the scheduled `*-standalone` smokes.

### What's new

- **`.github/workflows/smoke-standalone-latest.yml`** — a `workflow_dispatch`-only workflow that runs the released `threat-detect` binary at a non-default tag against each engine (`copilot`, `claude`, `codex`). Tag resolution precedence, logged to the run summary:
  1. `detector_tag` dispatch input
  2. `GH_AW_THREAT_DETECTION_VERSION` repo variable
  3. newest **prerelease** (auto)

  Each engine job installs the engine CLI, installs the resolved tag via the checksum-verifying `install_threat_detect_binary.sh`, and runs a detection over a minimal benign artifacts dir. The job passes when the binary produces a verdict (a `safe` or `threat` result both count); only a missing verdict / infra error fails it. `fail-fast: false` and a per-engine `engine` choice input let you test one engine or all.

- **`smoke.yml`** — new `include_latest` toggle (default **off**) and optional `detector_tag` to also dispatch the latest-prerelease smoke. Default pinned-smoke dispatch is unchanged.

- **README** — documents the new workflow and the **tag → test → promote** loop, and updates the `GH_AW_THREAT_DETECTION_VERSION` variable notes.

### Design notes

- The scheduled `*-standalone` smokes keep their reproducible compile-time pin (`install_threat_detect_binary.sh v0.2.2`); steady-state behaviour is untouched.
- gh-aw pins the detector tag at compile time and its `threat-detection.steps`/`post-steps` hooks run before the install / after execution, so they can't cleanly override the binary mid-detection. This workflow is therefore hand-authored (like `detection-only.yml`) and resolves the tag at runtime.
- It runs the binary directly on the runner to stay self-contained and avoid AWF image/version drift; the AWF execution path remains continuously validated by the pinned `*-standalone` smokes against the promoted release.

### Validation

- `actionlint` clean on `smoke-standalone-latest.yml` and `smoke.yml`.
- YAML parses; heredoc artifact generation and the prerelease-selection `jq` filter verified locally.