### PR TITLE
feat(engine): resolve detection model from native CLI env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ threat-detect [flags] <artifacts-dir>
 
 **Flags:**
 - `--engine` — AI engine to use (`copilot`, `claude`, `codex`). Default: `copilot`
-- `--model` — Model override for the engine
+- `--model` — Model override for the engine. When unset, the detector resolves the model from `GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}`, then the engine CLI's native model env var (`COPILOT_MODEL`, `ANTHROPIC_MODEL`)
 - `--prompt-template` — Path to custom prompt template
 - `--output` — Path to write JSON result (defaults to stdout)
 - `--log-file` — Path to write structured JSONL run logs (one JSON object per line). Env: `THREAT_DETECTION_LOG_FILE`
@@ -348,7 +348,7 @@ Optional Actions variables:
 | Variable | Purpose |
 |----------|---------|
 | `GH_AW_MODEL_AGENT_COPILOT`, `GH_AW_MODEL_AGENT_CLAUDE`, `GH_AW_MODEL_AGENT_CODEX` | Override the agent model for each smoke workflow. |
-| `GH_AW_MODEL_DETECTION_COPILOT`, `GH_AW_MODEL_DETECTION_CLAUDE`, `GH_AW_MODEL_DETECTION_CODEX` | Override the detection model for each engine. |
+| `GH_AW_MODEL_DETECTION_COPILOT`, `GH_AW_MODEL_DETECTION_CLAUDE`, `GH_AW_MODEL_DETECTION_CODEX` | Override the detection model for each engine. When `--model` is not passed, the detector reads the variable matching the selected engine; if it is unset, it falls back to the engine CLI's native model env var (`COPILOT_MODEL` for copilot, `ANTHROPIC_MODEL` for claude). |
 | `GH_AW_THREAT_DETECTION_VERSION` | Detector release tag downloaded by `detection-only.yml`, and the default override tag for `smoke-standalone-latest.yml` when its `detector_tag` input is empty (defaults to the latest promoted release for `detection-only.yml`, or the newest prerelease for `smoke-standalone-latest.yml`, when unset). The scheduled `*-standalone` smoke workflows instead pin a specific promoted tag at compile time for reproducibility. |
 
 ### Build

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -135,7 +135,8 @@ func run() (code int) {
 	}
 
 	// When --model is not set, fall back to the engine-specific detection model
-	// environment variable (GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}) so the
+	// environment variable (GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}) or the
+	// engine CLI's native model env var (COPILOT_MODEL, ANTHROPIC_MODEL), so the
 	// standalone detector honors the model gh-aw configured for detection.
 	model = engine.ResolveModel(engineID, model)
 

--- a/pkg/engine/codex_test.go
+++ b/pkg/engine/codex_test.go
@@ -121,11 +121,13 @@ func TestCodexConfigPathHonorsCodexHome(t *testing.T) {
 }
 
 func TestResolveModel(t *testing.T) {
-	// Ensure a clean slate for all detection-model env vars.
+	// Ensure a clean slate for all detection-model and native CLI model env vars.
 	for _, name := range []string{
 		"GH_AW_MODEL_DETECTION_COPILOT",
 		"GH_AW_MODEL_DETECTION_CLAUDE",
 		"GH_AW_MODEL_DETECTION_CODEX",
+		"COPILOT_MODEL",
+		"ANTHROPIC_MODEL",
 	} {
 		t.Setenv(name, "")
 	}
@@ -158,6 +160,30 @@ func TestResolveModel(t *testing.T) {
 		}
 	})
 
+	t.Run("copilot falls back to native COPILOT_MODEL", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_COPILOT", "")
+		t.Setenv("COPILOT_MODEL", "native-copilot-model")
+		if got := ResolveModel("copilot", ""); got != "native-copilot-model" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "native-copilot-model")
+		}
+	})
+
+	t.Run("claude falls back to native ANTHROPIC_MODEL", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_CLAUDE", "")
+		t.Setenv("ANTHROPIC_MODEL", "native-claude-model")
+		if got := ResolveModel("claude", ""); got != "native-claude-model" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "native-claude-model")
+		}
+	})
+
+	t.Run("detection env var takes precedence over native CLI env var", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_COPILOT", "detection-model")
+		t.Setenv("COPILOT_MODEL", "native-model")
+		if got := ResolveModel("copilot", ""); got != "detection-model" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "detection-model")
+		}
+	})
+
 	t.Run("empty engine uses default copilot env", func(t *testing.T) {
 		t.Setenv("GH_AW_MODEL_DETECTION_COPILOT", "default-engine-model")
 		if got := ResolveModel("", ""); got != "default-engine-model" {
@@ -175,6 +201,14 @@ func TestResolveModel(t *testing.T) {
 		t.Setenv("GH_AW_MODEL_DETECTION_CODEX", "  gpt-5.4  ")
 		if got := ResolveModel("codex", ""); got != "gpt-5.4" {
 			t.Fatalf("ResolveModel() = %q, want %q", got, "gpt-5.4")
+		}
+	})
+
+	t.Run("native CLI env value is trimmed", func(t *testing.T) {
+		t.Setenv("GH_AW_MODEL_DETECTION_COPILOT", "")
+		t.Setenv("COPILOT_MODEL", "  claude-sonnet-4.6  ")
+		if got := ResolveModel("copilot", ""); got != "claude-sonnet-4.6" {
+			t.Fatalf("ResolveModel() = %q, want %q", got, "claude-sonnet-4.6")
 		}
 	})
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -42,17 +42,64 @@ func Canonical(engineID string) string {
 	return strings.ToLower(engineID)
 }
 
-// ResolveModel returns the model to use for detection. An explicit flagModel
-// always wins. Otherwise it falls back to the engine-specific detection model
-// environment variable set by gh-aw (GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}),
-// so the standalone detector honors the same model the caller configured for the
-// base (harness-driven) detection path.
+// Native CLI model environment variables. Setting these is equivalent to
+// passing --model to the corresponding engine CLI. gh-aw uses the same names,
+// so honoring them keeps the standalone detector consistent with the harness.
+const (
+	// copilotCLIModelEnvVar is read natively by the Copilot CLI. gh-aw sets it
+	// (resolved from the GH_AW_MODEL_DETECTION_COPILOT Actions variable) in the
+	// compiled standalone detection step.
+	copilotCLIModelEnvVar = "COPILOT_MODEL"
+	// claudeCLIModelEnvVar is read natively by the Claude CLI.
+	claudeCLIModelEnvVar = "ANTHROPIC_MODEL"
+)
+
+// detectionModelEnvVar returns the gh-aw detection model environment variable
+// name for the given canonical engine ID
+// (GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}).
+func detectionModelEnvVar(canonicalEngineID string) string {
+	return "GH_AW_MODEL_DETECTION_" + strings.ToUpper(canonicalEngineID)
+}
+
+// nativeCLIModelEnvVar returns the engine CLI's own model environment variable
+// name for the given canonical engine ID, or "" when the engine's CLI has no
+// native model env var (Codex selects the model via a -c model= flag).
+func nativeCLIModelEnvVar(canonicalEngineID string) string {
+	switch canonicalEngineID {
+	case "copilot":
+		return copilotCLIModelEnvVar
+	case "claude":
+		return claudeCLIModelEnvVar
+	default:
+		return ""
+	}
+}
+
+// ResolveModel returns the model to use for detection, mirroring how gh-aw
+// configures the model for each engine. Resolution precedence:
+//
+//  1. an explicit flagModel (the --model flag) always wins;
+//  2. the engine-specific detection model variable set by gh-aw
+//     (GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX});
+//  3. the engine CLI's native model environment variable (COPILOT_MODEL for
+//     copilot, ANTHROPIC_MODEL for claude), which gh-aw sets directly for some
+//     engines in the compiled standalone detection step.
+//
+// This keeps the standalone detector consistent with the model the caller
+// configured for the base (harness-driven) detection path, and makes the
+// resolved model observable in logs and the run report.
 func ResolveModel(engineID, flagModel string) string {
 	if flagModel != "" {
 		return flagModel
 	}
-	envName := "GH_AW_MODEL_DETECTION_" + strings.ToUpper(Canonical(engineID))
-	return strings.TrimSpace(os.Getenv(envName))
+	canonical := Canonical(engineID)
+	if v := strings.TrimSpace(os.Getenv(detectionModelEnvVar(canonical))); v != "" {
+		return v
+	}
+	if native := nativeCLIModelEnvVar(canonical); native != "" {
+		return strings.TrimSpace(os.Getenv(native))
+	}
+	return ""
 }
 
 // New creates a new engine instance based on the engine ID.

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -225,6 +225,13 @@ treats a missing verdict as a recoverable `parse_error` and proceeds.
 | `WORKFLOW_DESCRIPTION` | Description of the workflow |
 | `CUSTOM_PROMPT` | Additional detection instructions |
 
+**TD-22a**: When the model is not set explicitly (via the `--model` flag or engine configuration), the detector MUST resolve the model for the selected engine from environment variables, in the following precedence:
+
+1. the engine-specific detection model variable `GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}`;
+2. the engine CLI's native model environment variable (`COPILOT_MODEL` for copilot, `ANTHROPIC_MODEL` for claude).
+
+This keeps the standalone detector consistent with the model `gh-aw` configures for the harness-driven detection path. Codex has no native model environment variable and relies solely on the detection variable.
+
 **TD-23**: AI engine authentication variables MUST be treated as runtime-only configuration. They MUST NOT be required for parser, prompt building, unit test, or binary smoke test execution.
 
 The implementation MAY pass through engine-specific authentication variables required by the selected CLI, including:


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KY35XFT679SR13XD5GFYTNNT)

## Summary

Fixes #382 — makes the standalone `threat-detect` binary's model resolution consistent with how `gh-aw` configures models across engines.

### Background

In the main `gh-aw` repo, the compiled **standalone** detection step passes the detection model to `threat-detect` differently per engine:

- **copilot**: sets the native `COPILOT_MODEL` env var directly (resolved from the `GH_AW_MODEL_DETECTION_COPILOT` Actions variable).
- **claude / codex**: set `GH_AW_MODEL_DETECTION_CLAUDE` / `GH_AW_MODEL_DETECTION_CODEX`.

Previously, `engine.ResolveModel` only read `GH_AW_MODEL_DETECTION_{ENGINE}`. For copilot this meant the resolved model was `""`, so the detector never reported/logged the model (the copilot CLI still honored the inherited `COPILOT_MODEL`, but resolution was inconsistent).

### Change

`ResolveModel` now resolves the model with this precedence:

1. explicit `--model` flag,
2. `GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}`,
3. the engine CLI's native model env var (`COPILOT_MODEL` for copilot, `ANTHROPIC_MODEL` for claude).

Codex has no native model env var (it uses `-c model=`), so it continues to rely solely on the detection variable. This keeps the standalone detector consistent with the harness-driven path and makes the resolved model observable in logs and the run report.

### Details

- `pkg/engine/engine.go`: extended `ResolveModel`; added `detectionModelEnvVar` / `nativeCLIModelEnvVar` helpers and native env var constants.
- `pkg/engine/codex_test.go`: added cases for native env var fallback, precedence, and trimming.
- `README.md`: documented the resolution precedence for `--model` and the detection variables.
- `specs/threat-detection-spec.md`: added requirement **TD-22a**.

### Testing

- `make fmt lint build` ✅
- `make test` ✅ (`TestResolveModel` covers the new precedence)

> Note: `make fmt-check` flags a pre-existing trailing-newline issue in `pkg/runlog/runlog_test.go` that is unrelated to this change and left untouched.