### PR TITLE
ci(release): build and publish linux/arm64 threat-detect binaries

### DIFF
--- a/.github/workflows/detection-only.yml
+++ b/.github/workflows/detection-only.yml
@@ -200,14 +200,19 @@ jobs:
           mkdir -p "$dest_dir"
           download_dir="$(mktemp -d)"
           trap 'rm -rf "$download_dir"' EXIT
-          args=(--repo "$DETECTOR_REPO" --pattern threat-detect-linux-amd64 --pattern checksums.txt --dir "$download_dir")
+          case "$(uname -m)" in
+            x86_64|amd64) asset="threat-detect-linux-amd64" ;;
+            aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+            *) echo "::error::Unsupported architecture: $(uname -m)"; exit 1 ;;
+          esac
+          args=(--repo "$DETECTOR_REPO" --pattern "$asset" --pattern checksums.txt --dir "$download_dir")
           if [ -n "${THREAT_DETECTION_VERSION:-}" ]; then
             gh release download "$THREAT_DETECTION_VERSION" "${args[@]}"
           else
             gh release download "${args[@]}"
           fi
           ( cd "$download_dir" && sha256sum --check --ignore-missing checksums.txt )
-          install -m 0755 "$download_dir/threat-detect-linux-amd64" "$dest_dir/threat-detect"
+          install -m 0755 "$download_dir/$asset" "$dest_dir/threat-detect"
       - name: Execute threat detection with AWF
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -22,50 +22,66 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify prerelease and binary asset
+      - name: Verify prerelease and binary assets
         id: verify
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          ASSET="threat-detect-linux-amd64"
           RELEASE_INFO=$(gh release view "$PROMOTE_TAG" --json body,isPrerelease,tagName)
           IS_PRERELEASE=$(echo "$RELEASE_INFO" | jq -r '.isPrerelease')
           if [ "$IS_PRERELEASE" != "true" ]; then
             echo "::error::Release ${PROMOTE_TAG} is not a prerelease. Nothing to promote."
             exit 1
           fi
-          # Extract the recorded binary asset digest from the release body.
-          DIGEST_LINE_PREFIX="Binary asset sha256: sha256:"
-          RECORDED_SHA256=""
-          while IFS= read -r line; do
-            case "$line" in
-              "$DIGEST_LINE_PREFIX"*)
-                RECORDED_SHA256="${line#Binary asset sha256: sha256:}"
-                break
-                ;;
-            esac
-          done < <(echo "$RELEASE_INFO" | jq -r '.body // ""')
-          if [ -z "$RECORDED_SHA256" ]; then
-            echo "::error::Release ${PROMOTE_TAG} does not record a binary asset sha256. Nothing to promote."
-            exit 1
-          fi
-          if ! echo "$RECORDED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
-            echo "::error::Release ${PROMOTE_TAG} records a binary asset sha256 with invalid format. Nothing to promote."
-            exit 1
-          fi
-          # Download the published asset and confirm it matches the recorded digest,
-          # so promotion can never mark a tampered or missing binary as Latest.
+          BODY=$(echo "$RELEASE_INFO" | jq -r '.body // ""')
+
           tmp="$(mktemp -d)"
           trap 'rm -rf "$tmp"' EXIT
-          gh release download "$PROMOTE_TAG" --pattern "$ASSET" --dir "$tmp"
-          ACTUAL_SHA256="$(sha256sum "$tmp/$ASSET" | awk '{print $1}')"
-          if [ "$ACTUAL_SHA256" != "$RECORDED_SHA256" ]; then
-            echo "::error::Release ${PROMOTE_TAG} asset sha256 ${ACTUAL_SHA256} does not match recorded ${RECORDED_SHA256}. Nothing to promote."
+
+          # Collect "<asset> <sha256>" pairs recorded in the release body. Newer
+          # releases record one line per asset:
+          #   Binary asset sha256 (threat-detect-linux-amd64): sha256:<hash>
+          # Legacy releases record a single amd64-only line:
+          #   Binary asset sha256: sha256:<hash>
+          pairs_file="$tmp/pairs.txt"
+          : > "$pairs_file"
+          while IFS= read -r line; do
+            case "$line" in
+              "Binary asset sha256 ("*"): sha256:"*)
+                asset="${line#Binary asset sha256 (}"
+                asset="${asset%%): sha256:*}"
+                sha="${line##*): sha256:}"
+                echo "${asset} ${sha}" >> "$pairs_file"
+                ;;
+              "Binary asset sha256: sha256:"*)
+                sha="${line#Binary asset sha256: sha256:}"
+                echo "threat-detect-linux-amd64 ${sha}" >> "$pairs_file"
+                ;;
+            esac
+          done < <(printf '%s\n' "$BODY")
+
+          if [ ! -s "$pairs_file" ]; then
+            echo "::error::Release ${PROMOTE_TAG} does not record any binary asset sha256. Nothing to promote."
             exit 1
           fi
-          echo "binary_sha256=sha256:${RECORDED_SHA256}" >> "$GITHUB_OUTPUT"
-          echo "✅ Verified ${PROMOTE_TAG} is a prerelease with binary asset sha256:${RECORDED_SHA256} — proceeding with promotion."
+
+          # Download each recorded asset and confirm it matches the recorded digest,
+          # so promotion can never mark a tampered or missing binary as Latest.
+          while read -r asset sha; do
+            if ! echo "$sha" | grep -Eq '^[0-9a-f]{64}$'; then
+              echo "::error::Release ${PROMOTE_TAG} records ${asset} with an invalid sha256 format. Nothing to promote."
+              exit 1
+            fi
+            gh release download "$PROMOTE_TAG" --pattern "$asset" --dir "$tmp"
+            actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+            if [ "$actual" != "$sha" ]; then
+              echo "::error::Release ${PROMOTE_TAG} asset ${asset} sha256 ${actual} does not match recorded ${sha}. Nothing to promote."
+              exit 1
+            fi
+            echo "✅ Verified ${asset} sha256:${sha}"
+          done < "$pairs_file"
+          echo "✅ ${PROMOTE_TAG} is a prerelease with all recorded binary assets verified — proceeding with promotion."
 
       - name: Promote release to stable
         env:

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -19,17 +19,19 @@ jobs:
         with:
           go-version: '1.26'
 
-      - name: Build main binary
+      - name: Build main binaries
         id: build
         run: |
           set -euo pipefail
           SHORT_SHA="${GITHUB_SHA:0:7}"
           VERSION="main-${SHORT_SHA}"
           mkdir -p dist
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
-            -o dist/threat-detect-linux-amd64 ./cmd/threat-detect
-          ( cd dist && sha256sum threat-detect-linux-amd64 > checksums.txt )
+          for GOARCH in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="${GOARCH}" go build \
+              -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
+              -o "dist/threat-detect-linux-${GOARCH}" ./cmd/threat-detect
+          done
+          ( cd dist && sha256sum threat-detect-linux-amd64 threat-detect-linux-arm64 > checksums.txt )
           {
             echo "short_sha=${SHORT_SHA}"
             echo "version=${VERSION}"
@@ -41,7 +43,17 @@ jobs:
           SHORT_SHA: ${{ steps.build.outputs.short_sha }}
         run: |
           set -euo pipefail
-          BINARY_SHA256="sha256:$(sha256sum dist/threat-detect-linux-amd64 | awk '{print $1}')"
+          # Record every release-asset SHA-256 in the release body, mirroring the
+          # tagged release workflow so downstream verification is consistent.
+          notes_file="$(mktemp)"
+          {
+            echo "Unverified branch build from ${GITHUB_SHA}."
+            for asset in threat-detect-linux-amd64 threat-detect-linux-arm64; do
+              asset_sha256="$(sha256sum "dist/${asset}" | awk '{print $1}')"
+              echo "Binary asset sha256 (${asset}): sha256:${asset_sha256}"
+            done
+            echo "The Latest release continues to track the most recently promoted version."
+          } > "$notes_file"
           # Move the rolling `main` pre-release to this commit. Deleting and
           # recreating keeps the `main` tag pointed at the freshest build, mirroring
           # the moving `:main` container tag. The Latest release (the most recently
@@ -49,9 +61,10 @@ jobs:
           gh release delete main --yes --cleanup-tag 2>/dev/null || true
           gh release create main \
             dist/threat-detect-linux-amd64#threat-detect-linux-amd64 \
+            dist/threat-detect-linux-arm64#threat-detect-linux-arm64 \
             dist/checksums.txt#checksums.txt \
             --title "main (edge build ${SHORT_SHA})" \
-            --notes "Unverified branch build from ${GITHUB_SHA}. Binary asset sha256: ${BINARY_SHA256}. The Latest release continues to track the most recently promoted version." \
+            --notes-file "$notes_file" \
             --target "${GITHUB_SHA}" \
             --prerelease
 
@@ -63,7 +76,7 @@ jobs:
             echo "## Published main binary"
             echo
             echo "- Rolling pre-release \`main\` updated to edge build \`${SHORT_SHA}\`"
-            echo "- Asset: \`threat-detect-linux-amd64\` (+ \`checksums.txt\`)"
+            echo "- Assets: \`threat-detect-linux-amd64\`, \`threat-detect-linux-arm64\` (+ \`checksums.txt\`)"
             echo
             echo "These are unverified branch builds. The Latest release is unaffected and continues to track the most recently promoted release."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,20 @@ jobs:
       - name: Run tests
         run: go test -v -race ./...
 
-      - name: Build release binary
+      - name: Build release binaries
         run: |
           VERSION=${GITHUB_REF_NAME}
           mkdir -p dist
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
-            -o dist/threat-detect-linux-amd64 ./cmd/threat-detect
+          for GOARCH in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="${GOARCH}" go build \
+              -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
+              -o "dist/threat-detect-linux-${GOARCH}" ./cmd/threat-detect
+          done
 
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum threat-detect-linux-amd64 > checksums.txt
+          sha256sum threat-detect-linux-amd64 threat-detect-linux-arm64 > checksums.txt
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -59,13 +61,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Record the release-asset SHA-256 in the release body so the promote
-          # workflow can verify and pin the exact binary that was published.
-          BINARY_SHA256="sha256:$(sha256sum dist/threat-detect-linux-amd64 | awk '{print $1}')"
+          set -euo pipefail
+          # Record every release-asset SHA-256 in the release body so the promote
+          # workflow can verify and pin the exact binaries that were published.
+          notes_file="$(mktemp)"
+          for asset in threat-detect-linux-amd64 threat-detect-linux-arm64; do
+            asset_sha256="$(sha256sum "dist/${asset}" | awk '{print $1}')"
+            echo "Binary asset sha256 (${asset}): sha256:${asset_sha256}" >> "$notes_file"
+          done
           gh release create "${GITHUB_REF_NAME}" \
             dist/threat-detect-linux-amd64#threat-detect-linux-amd64 \
+            dist/threat-detect-linux-arm64#threat-detect-linux-arm64 \
             dist/checksums.txt#checksums.txt \
             --title "${GITHUB_REF_NAME}" \
-            --notes "Binary asset sha256: ${BINARY_SHA256}" \
+            --notes-file "$notes_file" \
             --generate-notes \
             --prerelease

--- a/.github/workflows/replay-detection.yml
+++ b/.github/workflows/replay-detection.yml
@@ -306,12 +306,17 @@ jobs:
                 echo "::error::detector_ref must be set to a release tag when detector_source=release."
                 exit 1
               fi
+              case "$(uname -m)" in
+                x86_64|amd64) asset="threat-detect-linux-amd64" ;;
+                aarch64|arm64) asset="threat-detect-linux-arm64" ;;
+                *) echo "::error::Unsupported architecture: $(uname -m)"; exit 1 ;;
+              esac
               gh release download "$DETECTOR_REF" \
                 --repo "$GITHUB_REPOSITORY" \
-                --pattern threat-detect-linux-amd64 \
+                --pattern "$asset" \
                 --dir "${RUNNER_TEMP}/gh-aw-replay/bin"
-              chmod +x "${RUNNER_TEMP}/gh-aw-replay/bin/threat-detect-linux-amd64"
-              echo "DETECTOR_BIN=${RUNNER_TEMP}/gh-aw-replay/bin/threat-detect-linux-amd64" >> "$GITHUB_ENV"
+              chmod +x "${RUNNER_TEMP}/gh-aw-replay/bin/$asset"
+              echo "DETECTOR_BIN=${RUNNER_TEMP}/gh-aw-replay/bin/$asset" >> "$GITHUB_ENV"
               ;;
             *)
               echo "::error::Unsupported detector_source '${DETECTOR_SOURCE}'."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (and other coding agents) when workin
 The component runs in two main contexts:
 
 1. **As a host CLI** (`./bin/threat-detect <artifacts-dir>`) inside a `gh-aw`-generated detection job.
-2. **As a published release-asset binary** (`threat-detect-linux-amd64`, downloaded via `gh release download` from [`github/gh-aw-threat-detection` releases](https://github.com/github/gh-aw-threat-detection/releases)) installed on the runner and executed under the AWF firewall (see [AWF section below](#agentic-workflow-firewall-awf)).
+2. **As a published release-asset binary** (`threat-detect-linux-amd64` / `threat-detect-linux-arm64`, downloaded via `gh release download` from [`github/gh-aw-threat-detection` releases](https://github.com/github/gh-aw-threat-detection/releases)) installed on the runner and executed under the AWF firewall (see [AWF section below](#agentic-workflow-firewall-awf)).
 
 It detects three categories: **prompt injection**, **secret leak**, and **malicious patch**, and emits a strict JSON contract.
 
@@ -17,7 +17,7 @@ It detects three categories: **prompt injection**, **secret leak**, and **malici
 
 - **Language**: Go 1.26+ (module `github.com/github/gh-aw-threat-detection`)
 - **Binary**: `bin/threat-detect` (built via `make build`)
-- **Distribution**: published as GitHub Release assets (`threat-detect-linux-amd64` + `checksums.txt`); no container image
+- **Distribution**: published as GitHub Release assets (`threat-detect-linux-amd64`, `threat-detect-linux-arm64` + `checksums.txt`); no container image
 - **Spec**: [`specs/threat-detection-spec.md`](specs/threat-detection-spec.md) — W3C-style normative spec; the source of truth for behavior
 - **Engines supported**: `copilot` (default), `claude`, `codex` — invoked from `PATH`, not bundled into the binary
 - **Detection**: a single agentic CLI engine pass; the engine reports its verdict in-session via the `threat_detection_result` tool (out-of-band result sink), which is the sole source of the verdict
@@ -127,7 +127,7 @@ The detector reads the verdict exclusively from the out-of-band result sink. The
 Three workflows orchestrate releases:
 
 1. `.github/workflows/create-release-tag.yml` — manual; pushes `vX.Y.Z`.
-2. `.github/workflows/release.yml` — triggered by tag push; gated by `release-publish` environment; builds + publishes the `threat-detect-linux-amd64` binary as GitHub Release assets in a **prerelease**, recording the asset sha256 in the release notes.
+2. `.github/workflows/release.yml` — triggered by tag push; gated by `release-publish` environment; builds + publishes the `threat-detect-linux-amd64` and `threat-detect-linux-arm64` binaries as GitHub Release assets in a **prerelease**, recording each asset sha256 in the release notes.
 3. `.github/workflows/promote-release.yml` — manual; gated by `release-promote`; re-downloads the asset, verifies its sha256 against the recorded value, and marks the GitHub release **Latest** (stable).
 
 The `latest` (non-prerelease) GitHub release and "Latest" badge **only move on explicit promotion** — never automatically.

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -188,8 +188,9 @@ Releases follow a **prerelease → promote** model:
 
 2. **Build & Publish (automated)** — pushing a tag matching `v*` triggers the
    [release workflow](.github/workflows/release.yml). It builds the
-   `threat-detect-linux-amd64` binary, attaches it (plus `checksums.txt`) to a
-   **prerelease** on GitHub, and records the asset sha256 in the release notes.
+   `threat-detect-linux-amd64` and `threat-detect-linux-arm64` binaries,
+   attaches them (plus a shared `checksums.txt`) to a **prerelease** on GitHub,
+   and records each asset's sha256 in the release notes.
    The `release-publish` environment gate
    pauses the workflow before publishing so maintainers can abort if needed.
 
@@ -198,7 +199,7 @@ Releases follow a **prerelease → promote** model:
    **Actions → Promote Release → Run workflow**, entering the tag name. This
    workflow (gated by the `release-promote` environment):
    - verifies the release is still a prerelease
-   - re-downloads the asset and verifies its sha256 against the recorded value
+   - re-downloads each recorded asset and verifies its sha256 against the recorded value
    - marks the GitHub release as stable and explicitly selects it as Latest (`--prerelease=false --latest`)
 
 The GitHub "Latest" release pointer only moves
@@ -211,9 +212,9 @@ In addition to release tags, every push to `main` triggers the
 [publish-main workflow](.github/workflows/publish-main.yml), which builds the
 binary and republishes a single rolling `main` pre-release:
 
-- The `main` pre-release always carries the `threat-detect-linux-amd64` asset
-  built from the most recent successful build from `main`, versioned
-  `main-<shortsha>`.
+- The `main` pre-release always carries the `threat-detect-linux-amd64` and
+  `threat-detect-linux-arm64` assets built from the most recent successful build
+  from `main`, versioned `main-<shortsha>`.
 
 These are **unverified branch builds**. The `main` pre-release is not eligible
 for promotion. The **Latest** stable release pointer is
@@ -240,7 +241,7 @@ After the tag is pushed:
 
 1. Approve the `release-publish` environment gate when the workflow pauses.
 2. Verify the prerelease on the [Releases page](../../releases) and test the
-   version-tagged `threat-detect-linux-amd64` asset.
+   version-tagged `threat-detect-linux-amd64` / `threat-detect-linux-arm64` assets.
 3. When satisfied, go to **Actions → Promote Release**, enter the tag, and run
    the workflow. Approve the `release-promote` environment gate.
 4. Confirm the **Latest** release now resolves to the new version.

--- a/README.md
+++ b/README.md
@@ -178,15 +178,21 @@ log artifact) together with `gh-aw`'s `logs` tooling.
 
 ### Released binary
 
-The `threat-detect` binary is published as a GitHub Release asset
-(`threat-detect-linux-amd64`) alongside a `checksums.txt`. Download and run it
-directly:
+The `threat-detect` binary is published as GitHub Release assets
+(`threat-detect-linux-amd64` and `threat-detect-linux-arm64`) alongside a
+shared `checksums.txt`. Download the asset matching your runner architecture and
+run it directly:
 
 ```bash
+# Pick the asset for your architecture (amd64 or arm64).
+case "$(uname -m)" in
+  x86_64|amd64) asset=threat-detect-linux-amd64 ;;
+  aarch64|arm64) asset=threat-detect-linux-arm64 ;;
+esac
 gh release download --repo github/gh-aw-threat-detection \
-  --pattern threat-detect-linux-amd64 --pattern checksums.txt
+  --pattern "$asset" --pattern checksums.txt
 sha256sum --check --ignore-missing checksums.txt
-install -m 0755 threat-detect-linux-amd64 ./threat-detect
+install -m 0755 "$asset" ./threat-detect
 ./threat-detect /path/to/artifacts
 ```
 
@@ -231,7 +237,7 @@ Replay uses the dispatching repository's `GITHUB_TOKEN`; no extra replay token i
 Common dispatch examples:
 
 - Current checkout, direct CLI replay: set `run_id`, leave `detector_source=current`, `engine=copilot`, and `use_awf=false`.
-- Released detector replay: set `detector_source=release` and `detector_ref` to a release tag such as `v0.0.2`. The workflow downloads the `threat-detect-linux-amd64` asset and runs it on the host so the selected engine CLI can be installed there.
+- Released detector replay: set `detector_source=release` and `detector_ref` to a release tag such as `v0.0.2`. The workflow downloads the release asset matching the runner architecture (`threat-detect-linux-amd64` or `threat-detect-linux-arm64`) and runs it on the host so the selected engine CLI can be installed there.
 - Model comparison: set `model` to the engine-specific model name to pass through `--model`.
 - Additional detection instructions: set `custom_prompt`; it is passed as `CUSTOM_PROMPT` and appended to the default detector prompt.
 - AWF mode: set `use_awf=true` only on a runner image that already provides the `awf` CLI. Direct mode is the default.
@@ -262,9 +268,10 @@ Decisions for the unresolved extraction questions:
 ## Release Asset Setup
 
 The repository can remain private while publishing release assets. The release
-workflow builds `threat-detect-linux-amd64`, records its sha256 in the release
-notes, and attaches it (plus `checksums.txt`) to a GitHub **prerelease** using
-the automatic `GITHUB_TOKEN` with `contents: write`.
+workflow builds `threat-detect-linux-amd64` and `threat-detect-linux-arm64`,
+records each asset's sha256 in the release notes, and attaches them (plus a
+shared `checksums.txt`) to a GitHub **prerelease** using the automatic
+`GITHUB_TOKEN` with `contents: write`.
 
 Maintainers need to configure the following before the binary is consumed by `gh-aw`:
 
@@ -397,7 +404,7 @@ const DefaultThreatDetectionRepo    = "github/gh-aw-threat-detection"
 const DefaultThreatDetectionVersion = "v0.0.2"
 ```
 
-The detection job in compiled workflows downloads the pinned `threat-detect-linux-amd64` release asset and runs it instead of inline AI engine invocation.
+The detection job in compiled workflows downloads the pinned `threat-detect` release asset matching the runner architecture (`threat-detect-linux-amd64` or `threat-detect-linux-arm64`) and runs it instead of inline AI engine invocation.
 
 ## Specification
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KY367SAT1PD02GBRECCJX90R)

## Summary

Closes #377.

The `threat-detect` release currently ships only `threat-detect-linux-amd64`, so detection can't run on arm64 runners. gh-aw's installer (`install_threat_detect_binary.sh`) already knows how to fetch `threat-detect-linux-arm64` and verify it against a shared `checksums.txt` — this repo just wasn't producing that asset. This PR generates it, mirroring how `github/gh-aw` selects target architecture at download time.

## Changes

- **`release.yml`** — cross-builds `linux/amd64` **and** `linux/arm64` (`CGO_ENABLED=0`), lists both in `checksums.txt`, and records a per-asset sha256 line in the release notes.
- **`publish-main.yml`** — same matrix for the rolling `main` edge pre-release.
- **`promote-release.yml`** — verifies **every** asset sha256 recorded in the release body before promoting to Latest, with a backward-compatible fallback that still understands the legacy single-line amd64 format from existing releases.
- **`detection-only.yml` / `replay-detection.yml`** — select the release asset by runner architecture via `uname -m` (amd64/arm64), keeping checksum verification.
- **Docs** — README, DEVGUIDE, CLAUDE updated to mention the arm64 asset.

## Release notes format

New releases record one line per binary:

```
Binary asset sha256 (threat-detect-linux-amd64): sha256:<hash>
Binary asset sha256 (threat-detect-linux-arm64): sha256:<hash>
```

The promote workflow parses these and verifies each downloaded asset; releases still using the old `Binary asset sha256: sha256:<hash>` line continue to work (treated as amd64).

## Verification

- `GOOS=linux GOARCH=arm64 go build` produces a valid arm64 binary (`go version -m` reports `GOARCH=arm64`).
- `make build` + `go vet ./...` pass.
- All five edited workflows parse as valid YAML; the promote body-parser was unit-tested locally against both the new and legacy note formats.

No Go source changed; the binary itself is already architecture-independent Go.