### PR TITLE
ci: add workflow to recompile on new gh-aw releases

### DIFF
--- a/.github/workflows/update-gh-aw.yml
+++ b/.github/workflows/update-gh-aw.yml
@@ -1,0 +1,132 @@
+name: Update gh-aw
+
+# Watches github/gh-aw for new (pre)releases. When a newer version than the one
+# currently used to compile the workflows is published, it installs that gh-aw
+# CLI version, recompiles every agentic workflow (.md -> .lock.yml), and opens a
+# pull request with the regenerated files.
+#
+# GitHub Actions cannot subscribe to another repository's release event directly,
+# so this runs on a schedule (and can be dispatched manually). Prereleases are
+# included on purpose.
+
+on:
+  schedule:
+    # Every 6 hours.
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'gh-aw release tag to update to (e.g. v0.83.0). Leave empty to use the latest (pre)release.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-gh-aw
+  cancel-in-progress: false
+
+jobs:
+  update:
+    # Never run on forks.
+    if: ${{ github.repository == 'github/gh-aw-threat-detection' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve target and current gh-aw versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Current version = the compiler_version recorded in a compiled lock file.
+          current="$(grep -o '"compiler_version":"[^"]*"' .github/workflows/smoke-copilot.lock.yml | head -n1 | sed 's/.*:"//;s/"//')"
+          if [ -z "${current}" ]; then
+            echo "Could not determine current gh-aw version from lock files" >&2
+            exit 1
+          fi
+
+          if [ -n "${INPUT_VERSION}" ]; then
+            target="${INPUT_VERSION}"
+          else
+            # Latest published (pre)release, drafts excluded, most recent by publish date.
+            # The API returns releases newest-first, so the first page is sufficient.
+            target="$(gh api 'repos/github/gh-aw/releases?per_page=100' \
+              --jq 'map(select(.draft == false)) | sort_by(.published_at) | last | .tag_name')"
+          fi
+          if [ -z "${target}" ] || [ "${target}" = "null" ]; then
+            echo "Could not determine target gh-aw version" >&2
+            exit 1
+          fi
+
+          echo "current=${current}" >> "$GITHUB_OUTPUT"
+          echo "target=${target}" >> "$GITHUB_OUTPUT"
+          if [ "${current}" = "${target}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Current gh-aw: ${current}"
+          echo "Target  gh-aw: ${target}"
+
+      - name: Install gh-aw CLI
+        if: ${{ steps.versions.outputs.changed == 'true' }}
+        uses: github/gh-aw-actions/setup-cli@b6d1443e05b8716267fa19425b99aa4f12006b4a # v0.82.14
+        with:
+          version: ${{ steps.versions.outputs.target }}
+
+      - name: Recompile workflows
+        if: ${{ steps.versions.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh aw compile
+
+      - name: Create pull request
+        if: ${{ steps.versions.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ steps.versions.outputs.target }}
+          CURRENT: ${{ steps.versions.outputs.current }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Recompiling with ${TARGET} produced no changes; nothing to do."
+            exit 0
+          fi
+
+          branch="chore/update-gh-aw-${TARGET}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # If a PR branch already exists for this target, don't recreate it.
+          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            echo "Branch ${branch} already exists; assuming a PR is already open."
+            exit 0
+          fi
+
+          git checkout -b "${branch}"
+          git add -A
+          git commit \
+            -m "chore: recompile workflows for gh-aw ${TARGET}" \
+            -m "Regenerate .lock.yml files using gh-aw ${TARGET} (was ${CURRENT})." \
+            -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+          git push origin "${branch}"
+
+          body="$(printf 'Automated update triggered by a new github/gh-aw release.\n\n- **Previous compiler version:** %s\n- **New compiler version:** %s\n\nThe agentic workflow .lock.yml files were regenerated with `gh aw compile` using gh-aw %s. Review the diff before merging.\n\nRelease notes: https://github.com/github/gh-aw/releases/tag/%s\n' "${CURRENT}" "${TARGET}" "${TARGET}" "${TARGET}")"
+
+          gh pr create \
+            --title "chore: update gh-aw to ${TARGET}" \
+            --body "${body}" \
+            --head "${branch}" \
+            --base main

--- a/.github/workflows/update-gh-aw.yml
+++ b/.github/workflows/update-gh-aw.yml
@@ -38,6 +38,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Always branch from main, even when dispatched from another ref, so
+          # the update PR only contains regenerated workflow files.
+          ref: main
 
       - name: Resolve target and current gh-aw versions
         id: versions
@@ -57,10 +61,13 @@ jobs:
           if [ -n "${INPUT_VERSION}" ]; then
             target="${INPUT_VERSION}"
           else
-            # Latest published (pre)release, drafts excluded, most recent by publish date.
-            # The API returns releases newest-first, so the first page is sufficient.
-            target="$(gh api 'repos/github/gh-aw/releases?per_page=100' \
-              --jq 'map(select(.draft == false)) | sort_by(.published_at) | last | .tag_name')"
+            # Latest published (pre)release, drafts excluded. The releases
+            # endpoint is ordered by creation time, not publish time, and this
+            # repo has >100 releases, so paginate everything and pick the max
+            # published_at (ISO-8601 sorts lexicographically).
+            target="$(gh api repos/github/gh-aw/releases --paginate \
+              --jq '.[] | select(.draft == false) | [.published_at, .tag_name] | @tsv' \
+              | sort | tail -n1 | cut -f2)"
           fi
           if [ -z "${target}" ] || [ "${target}" = "null" ]; then
             echo "Could not determine target gh-aw version" >&2


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KY5DP7X6X1BE42A595QJ9FNT)

## What

Adds `.github/workflows/update-gh-aw.yml`, a workflow that watches [`github/gh-aw`](https://github.com/github/gh-aw) for new **(pre)releases** and, when one is newer than the `gh-aw` version currently used to compile this repo's agentic workflows, recompiles them and opens a PR with the regenerated `.lock.yml` files.

## Why

GitHub Actions can't subscribe to another repository's release event, so we poll on a schedule. This keeps the compiled `.lock.yml` files in sync with the latest `gh-aw` compiler without manual intervention.

## How it works

- **Triggers**: 6-hourly `schedule` + `workflow_dispatch` (optional `version` input to force a specific tag).
- **Detects updates**: reads the current `compiler_version` from a compiled lock file and compares it against the latest `github/gh-aw` release (drafts excluded, **prereleases included**, newest by publish date).
- **Recompiles**: installs the target `gh-aw` CLI via SHA-pinned `github/gh-aw-actions/setup-cli` and runs `gh aw compile`.
- **Opens a PR**: commits regenerated lock files on `chore/update-gh-aw-<tag>`; idempotent — skips if the branch already exists or if recompiling yields no diff.
- Guarded to the canonical repo (never runs on forks).

## Validation

- YAML + `actionlint` pass.
- Version-detection logic tested against live data (currently would propose `v0.82.14 → v0.83.0`).

## Note

PRs opened with the default `GITHUB_TOKEN` don't trigger downstream workflows (CI). If CI should run on these PRs, wire a PAT into the checkout/push/`gh pr create` steps.