### PR TITLE
fix(engine): pass codex -c model/provider flags after the exec subcommand

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -251,21 +251,27 @@ func claudeArgs(model string, allowBash bool) []string {
 }
 
 func codexArgs(model, provider, prompt string) []string {
-	args := []string{
-		"exec",
+	// The model and model_provider overrides MUST be passed as `-c` flags of the
+	// `exec` subcommand (i.e. after `exec`). Codex ignores `-c` config overrides
+	// placed before the subcommand, so prepending them silently drops the model
+	// and provider selection — causing Codex to fall back to its default `openai`
+	// provider (bypassing the AWF API proxy and hitting api.openai.com directly
+	// with the isolation placeholder key, which returns 401).
+	args := []string{"exec"}
+	if model != "" {
+		args = append(args, "-c", "model="+model)
+	}
+	if provider != "" {
+		args = append(args, "-c", "model_provider="+provider)
+	}
+	args = append(args,
 		"-c", "web_search=disabled",
 		"-c", "fetch=disabled",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--skip-git-repo-check",
 		"--",
 		prompt,
-	}
-	if provider != "" {
-		args = append([]string{"-c", "model_provider=" + provider}, args...)
-	}
-	if model != "" {
-		args = append([]string{"-c", "model=" + model}, args...)
-	}
+	)
 	return args
 }
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -201,8 +201,8 @@ func TestEngineCommandArgs(t *testing.T) {
 	t.Run("codex", func(t *testing.T) {
 		got := codexArgs("gpt-5-codex", "", "detect threats")
 		want := []string{
-			"-c", "model=gpt-5-codex",
 			"exec",
+			"-c", "model=gpt-5-codex",
 			"-c", "web_search=disabled",
 			"-c", "fetch=disabled",
 			"--dangerously-bypass-approvals-and-sandbox",
@@ -234,9 +234,9 @@ func TestEngineCommandArgs(t *testing.T) {
 	t.Run("codex with forced provider", func(t *testing.T) {
 		got := codexArgs("gpt-5-codex", "openai-proxy", "detect threats")
 		want := []string{
+			"exec",
 			"-c", "model=gpt-5-codex",
 			"-c", "model_provider=openai-proxy",
-			"exec",
 			"-c", "web_search=disabled",
 			"-c", "fetch=disabled",
 			"--dangerously-bypass-approvals-and-sandbox",


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KYADRH907EBW38F4PY25MV85)

## Problem

The Codex detection job fails (e.g. [run 30104717315](https://github.com/github/gh-aw-threat-detection/actions/runs/30104717315/job/89528142614)) even though the same engine succeeds in the agent run.

Codex hit `api.openai.com` directly with the AWF isolation placeholder key and got a 401:

```
model: gpt-5.6-sol        (requested gpt-5.4 — ignored)
provider: openai          (should be openai-proxy)
401 Unauthorized ... Incorrect API key provided: sk-place****************roxy
  url: https://api.openai.com/v1/responses
```

→ codex exits 1 → `threat-detect` exits 2 → no `detection_result.json` → the **Conclude threat detection** step fails.

## Root cause

`codexArgs` prepended `-c model=` and `-c model_provider=` **before** the `exec` subcommand. Codex ignores `-c` config overrides placed before the subcommand, so:

- the `codexForcedProvider` repair (`-c model_provider=openai-proxy`) was silently dropped, letting Codex fall back to its default `openai` provider — bypassing the AWF API proxy sidecar, and
- model selection (`--model` / `GH_AW_MODEL_DETECTION_CODEX`) was silently ignored too.

Proof: `-c model=gpt-5.4` is built purely from env (no config-file read), was passed before `exec`, and Codex still ran its default `gpt-5.6-sol`. The post-`exec` overrides (`-c web_search=disabled`, `-c fetch=disabled`) *did* take effect — confirming position, not config reading, is the culprit.

By contrast, the agent job works because gh-aw's `codex-harness` redirects the built-in `openai` provider to the proxy via `OPENAI_BASE_URL`, so it never depends on these `-c` overrides.

## Fix

Emit `-c model=` and `-c model_provider=` **after** `exec`, alongside the other overrides that already worked. This restores model selection and makes the existing `codexForcedProvider` safety net effective, routing detection through the AWF proxy like the agent job.

## Notes

There is also an upstream root cause in `gh-aw`: it emits the detection `config.toml` with `model_provider = "openai-proxy"` orphaned under the `[history]` table instead of at the top level, so Codex ignores it. That should be fixed separately in `gh-aw`; this PR is the correct, independent fix on the detector side (also defense-in-depth, since `codexForcedProvider` exists precisely to repair that class of misconfiguration).

## Testing

- Updated the three `codexArgs` test cases to expect the new ordering.
- `make fmt lint build test` all pass.