### PR TITLE
fix(engine): surface engine stdout on subprocess failure for diagnosable engine_error

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -345,10 +346,104 @@ func runCLIEnvWithSink(ctx context.Context, name string, args []string, stdinDat
 			}
 		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("%s exited with code %d: %s", name, exitErr.ExitCode(), stderr.String())
+			return "", engineExitError(name, exitErr.ExitCode(), stdout.String(), stderr.String())
 		}
 		return "", fmt.Errorf("failed to execute %s: %w", name, err)
 	}
 
 	return stdout.String(), nil
+}
+
+// maxEngineOutputInError bounds how much captured engine output is embedded in a
+// failure message, keeping the tail (where fatal errors and stack traces appear).
+const maxEngineOutputInError = 4000
+
+// engineExitError builds a diagnostic error for a non-zero engine exit. It
+// surfaces both stderr and stdout because engines that emit structured output
+// (notably `claude --output-format stream-json`) report the real failure —
+// e.g. an invalid model or an API 4xx — as a JSON line on stdout while leaving
+// stderr empty. Without stdout the caller only sees an opaque
+// "<engine> exited with code N", which is not actionable.
+func engineExitError(name string, exitCode int, stdout, stderr string) error {
+	var parts []string
+	if s := strings.TrimSpace(stderr); s != "" {
+		parts = append(parts, "stderr: "+tailTruncate(s, maxEngineOutputInError))
+	}
+	if s := strings.TrimSpace(stdout); s != "" {
+		if msg := extractStreamJSONError(s); msg != "" {
+			parts = append(parts, "engine error: "+tailTruncate(msg, maxEngineOutputInError))
+		} else {
+			parts = append(parts, "stdout: "+tailTruncate(s, maxEngineOutputInError))
+		}
+	}
+	if len(parts) == 0 {
+		parts = append(parts, "no output captured on stdout or stderr")
+	}
+	return fmt.Errorf("%s exited with code %d: %s", name, exitCode, strings.Join(parts, "; "))
+}
+
+// tailTruncate returns at most max characters from the end of s, prefixing an
+// ellipsis marker when content was dropped. The tail is kept because fatal
+// engine diagnostics are emitted last.
+func tailTruncate(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	return "...(truncated)... " + s[len(s)-max:]
+}
+
+// extractStreamJSONError scans newline-delimited JSON output (the format used by
+// the Claude CLI's stream-json mode) for objects that describe a failure and
+// returns a concatenated, human-readable summary. It returns "" when no
+// structured error is found, so callers can fall back to the raw stdout tail.
+func extractStreamJSONError(stdout string) string {
+	var messages []string
+	seen := make(map[string]struct{})
+	add := func(msg string) {
+		msg = strings.TrimSpace(msg)
+		if msg == "" {
+			return
+		}
+		if _, ok := seen[msg]; ok {
+			return
+		}
+		seen[msg] = struct{}{}
+		messages = append(messages, msg)
+	}
+
+	for _, line := range strings.Split(stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			continue
+		}
+		// Shape 1: {"type":"error","error":{"type":..,"message":..}}
+		if errField, ok := obj["error"].(map[string]any); ok {
+			if msg, ok := errField["message"].(string); ok {
+				add(msg)
+				continue
+			}
+		}
+		// Shape 2: {"type":"result","is_error":true,"result":"..."}
+		if isErr, _ := obj["is_error"].(bool); isErr {
+			if res, ok := obj["result"].(string); ok {
+				add(res)
+				continue
+			}
+			if sub, ok := obj["subtype"].(string); ok {
+				add(sub)
+				continue
+			}
+		}
+		// Shape 3: top-level {"type":"error","message":"..."}.
+		if t, _ := obj["type"].(string); t == "error" {
+			if msg, ok := obj["message"].(string); ok {
+				add(msg)
+			}
+		}
+	}
+	return strings.Join(messages, " | ")
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -248,4 +249,75 @@ func TestEngineCommandArgs(t *testing.T) {
 			t.Fatalf("codexArgs() = %#v, want %#v", got, want)
 		}
 	})
+}
+
+func TestEngineExitError(t *testing.T) {
+	tests := []struct {
+		name     string
+		stdout   string
+		stderr   string
+		wantSub  []string
+		wantMiss []string
+	}{
+		{
+			name:    "stderr only",
+			stderr:  "boom on stderr",
+			wantSub: []string{"exited with code 1", "stderr: boom on stderr"},
+		},
+		{
+			name:    "stream-json error on stdout with empty stderr",
+			stdout:  `{"type":"system"}` + "\n" + `{"type":"error","error":{"type":"invalid_request_error","message":"model: claude-bogus not found"}}`,
+			wantSub: []string{"engine error: model: claude-bogus not found"},
+		},
+		{
+			name:    "result is_error on stdout",
+			stdout:  `{"type":"result","subtype":"error_during_execution","is_error":true,"result":"credit balance too low"}`,
+			wantSub: []string{"engine error: credit balance too low"},
+		},
+		{
+			name:    "unstructured stdout falls back to raw",
+			stdout:  "panic: something bad",
+			wantSub: []string{"stdout: panic: something bad"},
+		},
+		{
+			name:    "no output at all",
+			wantSub: []string{"no output captured on stdout or stderr"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := engineExitError("claude", 1, tt.stdout, tt.stderr)
+			msg := err.Error()
+			for _, want := range tt.wantSub {
+				if !strings.Contains(msg, want) {
+					t.Errorf("error %q missing %q", msg, want)
+				}
+			}
+			for _, miss := range tt.wantMiss {
+				if strings.Contains(msg, miss) {
+					t.Errorf("error %q unexpectedly contains %q", msg, miss)
+				}
+			}
+		})
+	}
+}
+
+func TestTailTruncate(t *testing.T) {
+	if got := tailTruncate("short", 100); got != "short" {
+		t.Errorf("tailTruncate short = %q", got)
+	}
+	got := tailTruncate("abcdefghij", 4)
+	if !strings.HasSuffix(got, "ghij") {
+		t.Errorf("tailTruncate should keep tail, got %q", got)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("tailTruncate should mark truncation, got %q", got)
+	}
+}
+
+func TestExtractStreamJSONErrorNoError(t *testing.T) {
+	stdout := `{"type":"system","subtype":"init"}` + "\n" + `{"type":"result","subtype":"success","is_error":false}`
+	if msg := extractStreamJSONError(stdout); msg != "" {
+		t.Errorf("expected no error message, got %q", msg)
+	}
 }

--- a/pkg/engine/tool_test.go
+++ b/pkg/engine/tool_test.go
@@ -113,3 +113,17 @@ func TestRunCLIEnvWithSinkSurfacesErrorWithoutSink(t *testing.T) {
 		t.Fatal("expected error when no valid sink result exists")
 	}
 }
+
+// A failing engine that writes only to stdout (as claude --output-format
+// stream-json does) must still have that output surfaced in the error, so the
+// failure is diagnosable rather than an opaque exit code.
+func TestRunCLIEnvWithSinkIncludesStdoutOnFailure(t *testing.T) {
+	sink := filepath.Join(t.TempDir(), "missing.json")
+	_, err := runCLIEnvWithSink(context.Background(), "sh", []string{"-c", `echo '{"type":"error","error":{"message":"model not found: claude-bogus"}}'; exit 1`}, "", nil, sink)
+	if err == nil {
+		t.Fatal("expected error when no valid sink result exists")
+	}
+	if !strings.Contains(err.Error(), "model not found: claude-bogus") {
+		t.Fatalf("expected stdout error surfaced, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KYJF1NXFC4M9M3XAYX6QAHH2)

## Problem

Smoke Claude Standalone ([run 30294818395](https://github.com/github/gh-aw-threat-detection/actions/runs/30294818395)) still fails after #660, with an unhelpful error:

```
Error running detection: engine execution failed: claude exited with code 1:
THREAT_DETECTION_STATUS: reason=engine_error exit=2
```

Note the empty detail after `code 1:`. The `conclude` step then fails because no `detection_result.json` was written.

## Root cause of the *unhelpful log*

In `pkg/engine/engine.go`, on a non-zero engine exit we only embedded **stderr**:

```go
return "", fmt.Errorf("%s exited with code %d: %s", name, exitErr.ExitCode(), stderr.String())
```

Claude is invoked with `--print --output-format stream-json`. In that mode Claude reports the *real* failure (invalid model, API 4xx, credit balance, etc.) as a JSON line on **stdout** and leaves stderr empty. `threat-detect` captured that stdout and then **threw it away** on the error path, so every engine failure collapsed to an opaque `claude exited with code 1:`.

The observed run confirms it: stderr was empty, and the detection job never uploads its own api-proxy/firewall logs, so the actual Claude error is currently invisible everywhere.

## Fix

`engineExitError` now:
- includes **both** stderr and stdout (tail-truncated to 4 KB, since fatal output comes last), and
- parses Claude `stream-json` error shapes (`{"type":"error","error":{"message":…}}`, `{"is_error":true,"result":…}`, top-level `{"type":"error","message":…}`) into a readable `engine error: …` summary.

End-to-end, the message becomes actionable:

```
Error running detection: engine execution failed: claude exited with code 1: engine error: API error: model claude-sonnet-4.6 not found (400)
```

This flows into both `detection.log` and the `--log-file` JSONL run log, so the next smoke run will show *why* Claude exits 1 without a re-run.

## Scope / what this does not change

- I intentionally did **not** re-pin the model or change the smoke frontmatter again. #660 did correctly set `ANTHROPIC_MODEL=claude-sonnet-4.6` (verified: `threat-detect` resolved it and passed `--model claude-sonnet-4.6`), so the model *was* pinned — the failure is downstream of that and was masked by the discarded stdout. This change is what will reveal the remaining cause.
- The `safe-outputs.threat-detection.engine` placement is the gh-aw-sanctioned location for the detection engine (threat detection is the agentic gate in front of the safe-outputs job), so nesting engine/env there is expected, not a bug.

## Tests

Added unit tests for `engineExitError`, `tailTruncate`, `extractStreamJSONError`, plus a `runCLIEnvWithSink` test asserting stdout is surfaced on failure. `go vet` + full `go test ./...` pass.