### PR TITLE
fix(engine): surface harness output and engine diagnostics in detection job logs

### DIFF
--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -278,7 +278,7 @@ func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath
 		logger.Info("attempt_start", map[string]any{"attempt": i + 1, "attempts": attempts})
 		// Remove any stale sink result before each attempt.
 		os.Remove(sinkPath)
-		if _, err := eng.Analyze(ctx, currentPrompt, engine.AnalyzeOptions{ResultSinkPath: sinkPath}); err != nil {
+		if _, err := eng.Analyze(ctx, currentPrompt, engine.AnalyzeOptions{ResultSinkPath: sinkPath, Logger: logger}); err != nil {
 			return nil, fmt.Errorf("%w: %w", errEngineExecution, err)
 		}
 		// The verdict must be reported in-session through the

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/github/gh-aw-threat-detection/pkg/detector"
+	"github.com/github/gh-aw-threat-detection/pkg/runlog"
 )
 
 // AnalyzeOptions carries optional in-session reporting configuration.
@@ -22,6 +23,10 @@ type AnalyzeOptions struct {
 	// the engine provisions the wrapper on PATH, sets THREAT_DETECTION_RESULT_FILE,
 	// and cancels the subprocess as soon as a valid result is written to this path.
 	ResultSinkPath string
+	// Logger, when non-nil, receives structured diagnostic events for the engine
+	// invocation — including the resolved binary path, arg count, and model —
+	// so failures can be diagnosed even when the engine subprocess produces no output.
+	Logger *runlog.Logger
 }
 
 // Engine represents an AI engine capable of analyzing content for threats.
@@ -133,10 +138,12 @@ func (e *copilotEngine) Analyze(ctx context.Context, prompt string, opts Analyze
 	env = append(env, toolEnv...)
 
 	if _, ok := copilotHarnessPath(); ok {
+		logEngineInvoke(opts.Logger, nodeCommand(), copilotArgs("<prompt-file>"), e.model)
 		return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
 			return copilotCommand(promptPath)
 		}, "", env, opts.ResultSinkPath)
 	}
+	logEngineInvoke(opts.Logger, "copilot", copilotDirectArgs("<prompt-file>"), e.model)
 	return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
 		return "copilot", copilotDirectArgs(promptPath)
 	}, prompt, env, opts.ResultSinkPath)
@@ -154,7 +161,9 @@ func (e *claudeEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeO
 	}
 	defer cleanup()
 	enableBashTool := opts.ResultSinkPath != ""
-	return runCLIEnvWithSink(ctx, "claude", claudeArgs(e.model, enableBashTool), prompt, toolEnv, opts.ResultSinkPath)
+	args := claudeArgs(e.model, enableBashTool)
+	logEngineInvoke(opts.Logger, "claude", args, e.model)
+	return runCLIEnvWithSink(ctx, "claude", args, prompt, toolEnv, opts.ResultSinkPath)
 }
 
 // codexEngine implements Engine using the Codex CLI.
@@ -169,6 +178,9 @@ func (e *codexEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeOp
 	}
 	defer cleanup()
 	provider := codexForcedProvider(codexConfigPath())
+	// codexArgs embeds the prompt as the final positional argument; pass a
+	// placeholder here so the logged args do not expose the detection prompt.
+	logEngineInvoke(opts.Logger, "codex", codexArgs(e.model, provider, "<prompt>"), e.model)
 	return runCLIEnvWithSink(ctx, "codex", codexArgs(e.model, provider, ""), prompt, toolEnv, opts.ResultSinkPath)
 }
 
@@ -392,8 +404,44 @@ func tailTruncate(s string, max int) string {
 	return "...(truncated)... " + s[len(s)-max:]
 }
 
+// logEngineInvoke logs the engine subprocess invocation details to both the
+// structured run log and stderr. It is called immediately before the engine
+// process starts so that silent engine failures (exit with no output) leave
+// enough context in the logs to diagnose the root cause.
+//
+// args must not contain sensitive data (prompt text, API keys). For engines
+// that embed the prompt in argv (Codex), callers pass a safe placeholder.
+func logEngineInvoke(logger *runlog.Logger, name string, args []string, model string) {
+	resolvedPath, err := exec.LookPath(name)
+	if err != nil {
+		resolvedPath = ""
+	}
+
+	// Emit to stderr so the message appears in the GitHub Actions job log even
+	// when the engine subprocess produces no output of its own.
+	if resolvedPath != "" {
+		fmt.Fprintf(os.Stderr, "[threat-detect] engine invoke: %s (%s), args: %d\n", name, resolvedPath, len(args))
+	} else {
+		fmt.Fprintf(os.Stderr, "[threat-detect] engine invoke: %s (binary not found in PATH), args: %d\n", name, len(args))
+	}
+
+	fields := map[string]any{
+		"name":       name,
+		"args":       args,
+		"args_count": len(args),
+	}
+	if resolvedPath != "" {
+		fields["binary"] = resolvedPath
+	} else {
+		fields["binary_not_found"] = true
+	}
+	if model != "" {
+		fields["model"] = model
+	}
+	logger.Info("engine_invoke", fields)
+}
+
 // extractStreamJSONError scans newline-delimited JSON output (the format used by
-// the Claude CLI's stream-json mode) for objects that describe a failure and
 // returns a concatenated, human-readable summary. It returns "" when no
 // structured error is found, so callers can fall back to the raw stdout tail.
 func extractStreamJSONError(stdout string) string {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -137,8 +137,8 @@ func (e *copilotEngine) Analyze(ctx context.Context, prompt string, opts Analyze
 	defer cleanup()
 	env = append(env, toolEnv...)
 
-	if _, ok := copilotHarnessPath(); ok {
-		logEngineInvoke(opts.Logger, nodeCommand(), copilotArgs("<prompt-file>"), e.model)
+	if harnessPath, ok := copilotHarnessPath(); ok {
+		logEngineInvoke(opts.Logger, nodeCommand(), append([]string{harnessPath, copilotBinary()}, copilotArgs("<prompt-file>")...), e.model)
 		return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
 			return copilotCommand(promptPath)
 		}, "", env, opts.ResultSinkPath)
@@ -161,6 +161,13 @@ func (e *claudeEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeO
 	}
 	defer cleanup()
 	enableBashTool := opts.ResultSinkPath != ""
+
+	if harnessPath, ok := claudeHarnessPath(); ok {
+		logEngineInvoke(opts.Logger, nodeCommand(), append([]string{harnessPath, "claude"}, claudeHarnessArgs("<prompt-file>", e.model, enableBashTool)...), e.model)
+		return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
+			return nodeCommand(), append([]string{harnessPath, "claude"}, claudeHarnessArgs(promptPath, e.model, enableBashTool)...)
+		}, "", toolEnv, opts.ResultSinkPath)
+	}
 	args := claudeArgs(e.model, enableBashTool)
 	logEngineInvoke(opts.Logger, "claude", args, e.model)
 	return runCLIEnvWithSink(ctx, "claude", args, prompt, toolEnv, opts.ResultSinkPath)
@@ -178,8 +185,15 @@ func (e *codexEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeOp
 	}
 	defer cleanup()
 	provider := codexForcedProvider(codexConfigPath())
-	// codexArgs embeds the prompt as the final positional argument; pass a
-	// placeholder here so the logged args do not expose the detection prompt.
+
+	if harnessPath, ok := codexHarnessPath(); ok {
+		logEngineInvoke(opts.Logger, nodeCommand(), append([]string{harnessPath, "codex"}, codexHarnessArgs("<prompt-file>", e.model, provider)...), e.model)
+		return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
+			return nodeCommand(), append([]string{harnessPath, "codex"}, codexHarnessArgs(promptPath, e.model, provider)...)
+		}, "", toolEnv, opts.ResultSinkPath)
+	}
+	// Codex embeds the prompt as a positional argument; pass a placeholder here
+	// so the logged args do not expose the detection prompt.
 	logEngineInvoke(opts.Logger, "codex", codexArgs(e.model, provider, "<prompt>"), e.model)
 	return runCLIEnvWithSink(ctx, "codex", codexArgs(e.model, provider, ""), prompt, toolEnv, opts.ResultSinkPath)
 }
@@ -220,11 +234,26 @@ func copilotDirectArgs(promptPath string) []string {
 }
 
 func copilotHarnessPath() (string, bool) {
+	return engineHarnessPath("copilot_harness.cjs")
+}
+
+func claudeHarnessPath() (string, bool) {
+	return engineHarnessPath("claude_harness.cjs")
+}
+
+func codexHarnessPath() (string, bool) {
+	return engineHarnessPath("codex_harness.cjs")
+}
+
+// engineHarnessPath returns the absolute path to a gh-aw harness script and
+// true when the file exists. All engine harnesses live under the same
+// $RUNNER_TEMP/gh-aw/actions/ directory.
+func engineHarnessPath(filename string) (string, bool) {
 	runnerTemp := os.Getenv("RUNNER_TEMP")
 	if runnerTemp == "" {
 		return "", false
 	}
-	harnessPath := filepath.Join(runnerTemp, "gh-aw", "actions", "copilot_harness.cjs")
+	harnessPath := filepath.Join(runnerTemp, "gh-aw", "actions", filename)
 	if _, err := os.Stat(harnessPath); err != nil {
 		return "", false
 	}
@@ -263,6 +292,21 @@ func claudeArgs(model string, allowBash bool) []string {
 	return append(args, "-")
 }
 
+// claudeHarnessArgs builds the claude flags for harness invocation. It is
+// identical to claudeArgs except that it uses --prompt-file <path> instead of
+// the stdin sentinel "-", matching the invocation pattern used by the gh-aw
+// claude_harness.cjs script.
+func claudeHarnessArgs(promptPath, model string, allowBash bool) []string {
+	args := []string{"--print", "--verbose", "--output-format", "stream-json"}
+	if allowBash {
+		args = append(args, "--allowed-tools", "Bash")
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	return append(args, "--prompt-file", promptPath)
+}
+
 func codexArgs(model, provider, prompt string) []string {
 	// The model and model_provider overrides MUST be passed as `-c` flags of the
 	// `exec` subcommand (i.e. after `exec`). Codex ignores `-c` config overrides
@@ -284,6 +328,28 @@ func codexArgs(model, provider, prompt string) []string {
 		"--skip-git-repo-check",
 		"--",
 		prompt,
+	)
+	return args
+}
+
+// codexHarnessArgs builds the codex flags for harness invocation. It is
+// equivalent to codexArgs except that the prompt is passed via --prompt-file
+// <path> instead of being embedded as a positional argument, matching the
+// invocation pattern used by the gh-aw codex_harness.cjs script.
+func codexHarnessArgs(promptPath, model, provider string) []string {
+	args := []string{"exec"}
+	if model != "" {
+		args = append(args, "-c", "model="+model)
+	}
+	if provider != "" {
+		args = append(args, "-c", "model_provider="+provider)
+	}
+	args = append(args,
+		"-c", "web_search=disabled",
+		"-c", "fetch=disabled",
+		"--dangerously-bypass-approvals-and-sandbox",
+		"--skip-git-repo-check",
+		"--prompt-file", promptPath,
 	)
 	return args
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -413,8 +414,13 @@ func runCLIEnvWithSink(ctx context.Context, name string, args []string, stdinDat
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Tee both stdout and stderr to os.Stderr so that harness lifecycle output
+	// ([copilot-harness], [claude-harness], [codex-harness]) and engine errors
+	// appear in the GitHub Actions job log in real-time, mirroring the agent
+	// job's "2>&1 | tee" pattern. The buffers are still populated for error
+	// reporting and sink-result checking.
+	cmd.Stdout = io.MultiWriter(&stdout, os.Stderr)
+	cmd.Stderr = io.MultiWriter(&stderr, os.Stderr)
 
 	if err := cmd.Run(); err != nil {
 		if sinkPath != "" {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -199,6 +199,66 @@ func TestEngineCommandArgs(t *testing.T) {
 		}
 	})
 
+	t.Run("claude harness args", func(t *testing.T) {
+		got := claudeHarnessArgs("/tmp/prompt.txt", "claude-sonnet-4.6", true)
+		want := []string{"--print", "--verbose", "--output-format", "stream-json", "--allowed-tools", "Bash", "--model", "claude-sonnet-4.6", "--prompt-file", "/tmp/prompt.txt"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("claudeHarnessArgs() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("claude harness command", func(t *testing.T) {
+		t.Setenv("GH_AW_NODE_BIN", "/custom/node")
+		runnerTemp := t.TempDir()
+		t.Setenv("RUNNER_TEMP", runnerTemp)
+		harnessPath := filepath.Join(runnerTemp, "gh-aw", "actions", "claude_harness.cjs")
+		if err := os.MkdirAll(filepath.Dir(harnessPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(harnessPath, []byte(""), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		gotName, gotArgs := nodeCommand(), append([]string{harnessPath, "claude"}, claudeHarnessArgs("/tmp/prompt.txt", "claude-sonnet-4.6", true)...)
+		wantName := "/custom/node"
+		wantArgs := []string{
+			harnessPath, "claude",
+			"--print", "--verbose", "--output-format", "stream-json",
+			"--allowed-tools", "Bash",
+			"--model", "claude-sonnet-4.6",
+			"--prompt-file", "/tmp/prompt.txt",
+		}
+		if gotName != wantName {
+			t.Fatalf("claude harness command name = %q, want %q", gotName, wantName)
+		}
+		if !reflect.DeepEqual(gotArgs, wantArgs) {
+			t.Fatalf("claude harness command args = %#v, want %#v", gotArgs, wantArgs)
+		}
+	})
+
+	t.Run("claude harness path detected", func(t *testing.T) {
+		runnerTemp := t.TempDir()
+		t.Setenv("RUNNER_TEMP", runnerTemp)
+		harnessPath := filepath.Join(runnerTemp, "gh-aw", "actions", "claude_harness.cjs")
+		if err := os.MkdirAll(filepath.Dir(harnessPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(harnessPath, []byte(""), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		got, ok := claudeHarnessPath()
+		if !ok || got != harnessPath {
+			t.Fatalf("claudeHarnessPath() = (%q, %v), want (%q, true)", got, ok, harnessPath)
+		}
+	})
+
+	t.Run("claude harness path absent", func(t *testing.T) {
+		t.Setenv("RUNNER_TEMP", t.TempDir())
+		if _, ok := claudeHarnessPath(); ok {
+			t.Fatal("claudeHarnessPath() = true when harness absent, want false")
+		}
+	})
+
 	t.Run("codex", func(t *testing.T) {
 		got := codexArgs("gpt-5-codex", "", "detect threats")
 		want := []string{
@@ -247,6 +307,78 @@ func TestEngineCommandArgs(t *testing.T) {
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("codexArgs() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("codex harness args", func(t *testing.T) {
+		got := codexHarnessArgs("/tmp/prompt.txt", "gpt-5-codex", "openai-proxy")
+		want := []string{
+			"exec",
+			"-c", "model=gpt-5-codex",
+			"-c", "model_provider=openai-proxy",
+			"-c", "web_search=disabled",
+			"-c", "fetch=disabled",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--skip-git-repo-check",
+			"--prompt-file", "/tmp/prompt.txt",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("codexHarnessArgs() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("codex harness command", func(t *testing.T) {
+		t.Setenv("GH_AW_NODE_BIN", "/custom/node")
+		runnerTemp := t.TempDir()
+		t.Setenv("RUNNER_TEMP", runnerTemp)
+		harnessPath := filepath.Join(runnerTemp, "gh-aw", "actions", "codex_harness.cjs")
+		if err := os.MkdirAll(filepath.Dir(harnessPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(harnessPath, []byte(""), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		gotName, gotArgs := nodeCommand(), append([]string{harnessPath, "codex"}, codexHarnessArgs("/tmp/prompt.txt", "gpt-5-codex", "")...)
+		wantName := "/custom/node"
+		wantArgs := []string{
+			harnessPath, "codex",
+			"exec",
+			"-c", "model=gpt-5-codex",
+			"-c", "web_search=disabled",
+			"-c", "fetch=disabled",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--skip-git-repo-check",
+			"--prompt-file", "/tmp/prompt.txt",
+		}
+		if gotName != wantName {
+			t.Fatalf("codex harness command name = %q, want %q", gotName, wantName)
+		}
+		if !reflect.DeepEqual(gotArgs, wantArgs) {
+			t.Fatalf("codex harness command args = %#v, want %#v", gotArgs, wantArgs)
+		}
+	})
+
+	t.Run("codex harness path detected", func(t *testing.T) {
+		runnerTemp := t.TempDir()
+		t.Setenv("RUNNER_TEMP", runnerTemp)
+		harnessPath := filepath.Join(runnerTemp, "gh-aw", "actions", "codex_harness.cjs")
+		if err := os.MkdirAll(filepath.Dir(harnessPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(harnessPath, []byte(""), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		got, ok := codexHarnessPath()
+		if !ok || got != harnessPath {
+			t.Fatalf("codexHarnessPath() = (%q, %v), want (%q, true)", got, ok, harnessPath)
+		}
+	})
+
+	t.Run("codex harness path absent", func(t *testing.T) {
+		t.Setenv("RUNNER_TEMP", t.TempDir())
+		if _, ok := codexHarnessPath(); ok {
+			t.Fatal("codexHarnessPath() = true when harness absent, want false")
 		}
 	})
 }


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KYNCGZZKMTCF6P0GZ7WFWF61)

## Problem

Detection jobs for all three engines (Copilot, Claude, Codex) produced no visible output in the GitHub Actions log. When `claude` exited with code 1 and zero output, the only signal was `"no output captured on stdout or stderr"`. Even successful Copilot runs showed no `[copilot-harness]` lifecycle lines.

Two root causes:

1. **No harness for Claude/Codex** — Copilot already routed through `copilot_harness.cjs`, but Claude and Codex invoked their binaries directly, bypassing the harness scripts that produce `[*-harness]` process lifecycle logging.
2. **Output buffered, never shown** — `runCLIEnvWithSink` captured engine stdout/stderr into in-memory buffers only. Nothing was written to the terminal, even on success.

## Changes

### `fix(engine): tee engine stdout/stderr to os.Stderr for real-time visibility`
Use `io.MultiWriter` to tee both stdout and stderr to `os.Stderr` while still populating the capture buffers for error reporting. Mirrors the agent job's `2>&1 | tee` pattern — `[*-harness]` output and engine errors now appear in the Actions job log in real-time.

### `feat(engine): use claude_harness.cjs and codex_harness.cjs when available`
- Adds `claudeHarnessPath()` / `codexHarnessPath()` via a shared `engineHarnessPath` helper (refactors `copilotHarnessPath()` to use it too)
- Adds `claudeHarnessArgs` / `codexHarnessArgs`: same flags as the direct invocation but using `--prompt-file <path>` instead of stdin `-` or `-- <prompt>`, matching the gh-aw agent invocation pattern
- `claudeEngine.Analyze` and `codexEngine.Analyze` now route through the harness via `runCLIWithPromptFile` when the harness script is present, falling back to direct invocation otherwise
- Fixes the Copilot `logEngineInvoke` call to include the harness path and binary in the logged args (was missing both)

### `feat(engine): log engine invocation details before subprocess runs`
Adds an `engine_invoke` structured log event (to both the JSONL run log and stderr) immediately before each engine subprocess starts, capturing:
- `name` — engine binary name
- `binary` — resolved path from `exec.LookPath` (or `binary_not_found: true`)
- `args` / `args_count` — flags passed (Codex uses `<prompt>` placeholder)
- `model` — resolved model when non-empty

Threads `AnalyzeOptions.Logger *runlog.Logger` from `analyzeWithRetries` in `main.go` through each engine's `Analyze` method.