### PR TITLE
feat(engine): surface engine and model in invoke log

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -139,12 +139,12 @@ func (e *copilotEngine) Analyze(ctx context.Context, prompt string, opts Analyze
 	env = append(env, toolEnv...)
 
 	if harnessPath, ok := copilotHarnessPath(); ok {
-		logEngineInvoke(opts.Logger, nodeCommand(), append([]string{harnessPath, copilotBinary()}, copilotArgs("<prompt-file>")...), e.model)
+		logEngineInvoke(opts.Logger, "copilot", nodeCommand(), append([]string{harnessPath, copilotBinary()}, copilotArgs("<prompt-file>")...), e.model)
 		return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
 			return copilotCommand(promptPath)
 		}, "", env, opts.ResultSinkPath)
 	}
-	logEngineInvoke(opts.Logger, "copilot", copilotDirectArgs("<prompt-file>"), e.model)
+	logEngineInvoke(opts.Logger, "copilot", "copilot", copilotDirectArgs("<prompt-file>"), e.model)
 	return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
 		return "copilot", copilotDirectArgs(promptPath)
 	}, prompt, env, opts.ResultSinkPath)
@@ -164,13 +164,13 @@ func (e *claudeEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeO
 	enableBashTool := opts.ResultSinkPath != ""
 
 	if harnessPath, ok := claudeHarnessPath(); ok {
-		logEngineInvoke(opts.Logger, nodeCommand(), append([]string{harnessPath, "claude"}, claudeHarnessArgs("<prompt-file>", e.model, enableBashTool)...), e.model)
+		logEngineInvoke(opts.Logger, "claude", nodeCommand(), append([]string{harnessPath, "claude"}, claudeHarnessArgs("<prompt-file>", e.model, enableBashTool)...), e.model)
 		return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
 			return nodeCommand(), append([]string{harnessPath, "claude"}, claudeHarnessArgs(promptPath, e.model, enableBashTool)...)
 		}, "", toolEnv, opts.ResultSinkPath)
 	}
 	args := claudeArgs(e.model, enableBashTool)
-	logEngineInvoke(opts.Logger, "claude", args, e.model)
+	logEngineInvoke(opts.Logger, "claude", "claude", args, e.model)
 	return runCLIEnvWithSink(ctx, "claude", args, prompt, toolEnv, opts.ResultSinkPath)
 }
 
@@ -188,14 +188,14 @@ func (e *codexEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeOp
 	provider := codexForcedProvider(codexConfigPath())
 
 	if harnessPath, ok := codexHarnessPath(); ok {
-		logEngineInvoke(opts.Logger, nodeCommand(), append([]string{harnessPath, "codex"}, codexHarnessArgs("<prompt-file>", e.model, provider)...), e.model)
+		logEngineInvoke(opts.Logger, "codex", nodeCommand(), append([]string{harnessPath, "codex"}, codexHarnessArgs("<prompt-file>", e.model, provider)...), e.model)
 		return runCLIWithPromptFile(ctx, prompt, func(promptPath string) (string, []string) {
 			return nodeCommand(), append([]string{harnessPath, "codex"}, codexHarnessArgs(promptPath, e.model, provider)...)
 		}, "", toolEnv, opts.ResultSinkPath)
 	}
 	// Codex embeds the prompt as a positional argument; pass a placeholder here
 	// so the logged args do not expose the detection prompt.
-	logEngineInvoke(opts.Logger, "codex", codexArgs(e.model, provider, "<prompt>"), e.model)
+	logEngineInvoke(opts.Logger, "codex", "codex", codexArgs(e.model, provider, "<prompt>"), e.model)
 	return runCLIEnvWithSink(ctx, "codex", codexArgs(e.model, provider, ""), prompt, toolEnv, opts.ResultSinkPath)
 }
 
@@ -483,21 +483,40 @@ func tailTruncate(s string, max int) string {
 //
 // args must not contain sensitive data (prompt text, API keys). For engines
 // that embed the prompt in argv (Codex), callers pass a safe placeholder.
-func logEngineInvoke(logger *runlog.Logger, name string, args []string, model string) {
+//
+// engineID is the canonical engine selected by the user (copilot/claude/codex),
+// while name is the process actually spawned — which is often "node" when the
+// gh-aw harness wrapper is used. Logging both makes the job log unambiguous
+// about which engine and model were requested.
+func logEngineInvoke(logger *runlog.Logger, engineID, name string, args []string, model string) {
 	resolvedPath, err := exec.LookPath(name)
 	if err != nil {
 		resolvedPath = ""
 	}
 
-	// Emit to stderr so the message appears in the GitHub Actions job log even
-	// when the engine subprocess produces no output of its own.
-	if resolvedPath != "" {
-		fmt.Fprintf(os.Stderr, "[threat-detect] engine invoke: %s (%s), args: %d\n", name, resolvedPath, len(args))
-	} else {
-		fmt.Fprintf(os.Stderr, "[threat-detect] engine invoke: %s (binary not found in PATH), args: %d\n", name, len(args))
+	// Describe the model on stderr so the job log makes clear which model each
+	// engine was asked for. An empty model means no override was passed and the
+	// engine CLI selects its own default.
+	modelDesc := model
+	if modelDesc == "" {
+		modelDesc = "(engine default)"
 	}
 
+	// Note when the actual process differs from the engine (harness wrapper),
+	// so "node" in the command does not obscure which engine is running.
+	command := name
+	if resolvedPath != "" {
+		command = fmt.Sprintf("%s (%s)", name, resolvedPath)
+	} else {
+		command = fmt.Sprintf("%s (binary not found in PATH)", name)
+	}
+
+	// Emit to stderr so the message appears in the GitHub Actions job log even
+	// when the engine subprocess produces no output of its own.
+	fmt.Fprintf(os.Stderr, "[threat-detect] engine invoke: engine=%s model=%s command=%s args=%d\n", engineID, modelDesc, command, len(args))
+
 	fields := map[string]any{
+		"engine":     engineID,
 		"name":       name,
 		"args":       args,
 		"args_count": len(args),

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -515,7 +515,7 @@ func logEngineInvoke(logger *runlog.Logger, engineID, name string, args []string
 	// newlines or terminal control sequences would otherwise split or forge the
 	// diagnostic line, and quoting keeps any control characters escaped on one
 	// physical line.
-	modelDesc := "(engine default)"
+	modelDesc := "(none; using engine default)"
 	if model != "" {
 		modelDesc = fmt.Sprintf("%q", model)
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -476,6 +476,11 @@ func tailTruncate(s string, max int) string {
 	return "...(truncated)... " + s[len(s)-max:]
 }
 
+// engineInvokeStderr is the destination for the human-readable engine-invoke
+// line. It is a package variable so tests can capture the emitted output; in
+// production it is os.Stderr, matching the GitHub Actions job log.
+var engineInvokeStderr io.Writer = os.Stderr
+
 // logEngineInvoke logs the engine subprocess invocation details to both the
 // structured run log and stderr. It is called immediately before the engine
 // process starts so that silent engine failures (exit with no output) leave
@@ -494,14 +499,6 @@ func logEngineInvoke(logger *runlog.Logger, engineID, name string, args []string
 		resolvedPath = ""
 	}
 
-	// Describe the model on stderr so the job log makes clear which model each
-	// engine was asked for. An empty model means no override was passed and the
-	// engine CLI selects its own default.
-	modelDesc := model
-	if modelDesc == "" {
-		modelDesc = "(engine default)"
-	}
-
 	// Note when the actual process differs from the engine (harness wrapper),
 	// so "node" in the command does not obscure which engine is running.
 	command := name
@@ -511,9 +508,21 @@ func logEngineInvoke(logger *runlog.Logger, engineID, name string, args []string
 		command = fmt.Sprintf("%s (binary not found in PATH)", name)
 	}
 
+	// Describe the model on stderr so the job log makes clear which model each
+	// engine was asked for. An empty model means no override was passed and the
+	// engine CLI selects its own default. The model can originate from --model or
+	// an environment variable, so it is quoted with %q: a value containing
+	// newlines or terminal control sequences would otherwise split or forge the
+	// diagnostic line, and quoting keeps any control characters escaped on one
+	// physical line.
+	modelDesc := "(engine default)"
+	if model != "" {
+		modelDesc = fmt.Sprintf("%q", model)
+	}
+
 	// Emit to stderr so the message appears in the GitHub Actions job log even
 	// when the engine subprocess produces no output of its own.
-	fmt.Fprintf(os.Stderr, "[threat-detect] engine invoke: engine=%s model=%s command=%s args=%d\n", engineID, modelDesc, command, len(args))
+	fmt.Fprintf(engineInvokeStderr, "[threat-detect] engine invoke: engine=%s model=%s command=%s args=%d\n", engineID, modelDesc, command, len(args))
 
 	fields := map[string]any{
 		"engine":     engineID,

--- a/pkg/engine/log_test.go
+++ b/pkg/engine/log_test.go
@@ -1,0 +1,108 @@
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/github/gh-aw-threat-detection/pkg/runlog"
+)
+
+// captureEngineInvoke runs logEngineInvoke with the given inputs, redirecting
+// the stderr line into a buffer and the structured record into an in-memory
+// JSONL logger. It returns the raw stderr text and the decoded engine_invoke
+// record.
+func captureEngineInvoke(t *testing.T, engineID, name string, args []string, model string) (string, map[string]any) {
+	t.Helper()
+
+	var stderr bytes.Buffer
+	prev := engineInvokeStderr
+	engineInvokeStderr = &stderr
+	t.Cleanup(func() { engineInvokeStderr = prev })
+
+	var jsonl bytes.Buffer
+	logger := runlog.New(&jsonl)
+
+	logEngineInvoke(logger, engineID, name, args, model)
+
+	var record map[string]any
+	if line := strings.TrimSpace(jsonl.String()); line != "" {
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decoding engine_invoke record: %v (line: %q)", err, line)
+		}
+	}
+	return stderr.String(), record
+}
+
+func TestLogEngineInvoke_ExplicitModel(t *testing.T) {
+	// Use a binary name that will not resolve in PATH so the assertion is
+	// deterministic regardless of the host toolchain.
+	stderr, record := captureEngineInvoke(t, "codex", "definitely-not-a-real-binary", []string{"exec", "--", "<prompt>"}, "gpt-5-codex")
+
+	if !strings.HasPrefix(stderr, "[threat-detect] engine invoke: ") {
+		t.Fatalf("unexpected stderr prefix: %q", stderr)
+	}
+	for _, want := range []string{"engine=codex", `model="gpt-5-codex"`, "args=3"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr %q missing %q", stderr, want)
+		}
+	}
+	if !strings.HasSuffix(stderr, "\n") {
+		t.Errorf("stderr should end with a newline: %q", stderr)
+	}
+
+	if got := record["event"]; got != "engine_invoke" {
+		t.Errorf("event = %v, want engine_invoke", got)
+	}
+	if got := record["engine"]; got != "codex" {
+		t.Errorf("engine = %v, want codex", got)
+	}
+	if got := record["model"]; got != "gpt-5-codex" {
+		t.Errorf("model = %v, want gpt-5-codex", got)
+	}
+	if got := record["args_count"]; got != float64(3) {
+		t.Errorf("args_count = %v, want 3", got)
+	}
+}
+
+func TestLogEngineInvoke_EmptyModelFallback(t *testing.T) {
+	stderr, record := captureEngineInvoke(t, "claude", "definitely-not-a-real-binary", nil, "")
+
+	if !strings.Contains(stderr, "engine=claude") {
+		t.Errorf("stderr %q missing engine=claude", stderr)
+	}
+	if !strings.Contains(stderr, "model=(engine default)") {
+		t.Errorf("stderr %q missing model=(engine default)", stderr)
+	}
+
+	// An empty model must not be emitted as a structured field.
+	if _, ok := record["model"]; ok {
+		t.Errorf("record should omit model when empty, got %v", record["model"])
+	}
+	if got := record["engine"]; got != "claude" {
+		t.Errorf("engine = %v, want claude", got)
+	}
+}
+
+func TestLogEngineInvoke_EscapesControlCharacters(t *testing.T) {
+	// A model value carrying a newline and terminal control sequence must not
+	// split or forge the single-line diagnostic. Quoting keeps it on one line
+	// with the control characters escaped.
+	malicious := "evil\n[threat-detect] engine invoke: forged\x1b[31m"
+	stderr, record := captureEngineInvoke(t, "copilot", "definitely-not-a-real-binary", []string{"a"}, malicious)
+
+	if strings.Count(stderr, "\n") != 1 {
+		t.Errorf("stderr should be a single physical line, got %q", stderr)
+	}
+	if strings.Contains(stderr, "\x1b") {
+		t.Errorf("stderr should not contain a raw escape byte: %q", stderr)
+	}
+	if !strings.Contains(stderr, `\n`) || !strings.Contains(stderr, `\x1b`) {
+		t.Errorf("stderr should contain escaped control characters: %q", stderr)
+	}
+	// The structured field preserves the exact value (JSON handles escaping).
+	if got := record["model"]; got != malicious {
+		t.Errorf("record model = %q, want %q", got, malicious)
+	}
+}

--- a/pkg/engine/log_test.go
+++ b/pkg/engine/log_test.go
@@ -72,8 +72,8 @@ func TestLogEngineInvoke_EmptyModelFallback(t *testing.T) {
 	if !strings.Contains(stderr, "engine=claude") {
 		t.Errorf("stderr %q missing engine=claude", stderr)
 	}
-	if !strings.Contains(stderr, "model=(engine default)") {
-		t.Errorf("stderr %q missing model=(engine default)", stderr)
+	if !strings.Contains(stderr, "model=(none; using engine default)") {
+		t.Errorf("stderr %q missing model=(none; using engine default)", stderr)
 	}
 
 	// An empty model must not be emitted as a structured field.


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KYT63JYC7A9JSS9MCSE0FMN4)

## Problem

The single threat-detection log step doesn't make clear which engine and model each detection run is asking for. The engine-invoke stderr line looked like:

```
[threat-detect] engine invoke: node (/opt/hostedtoolcache/node/24.18.0/x64/bin/node), args: 13
```

Two issues:
- The command shows `node` (the gh-aw harness wrapper) rather than the actual engine (`copilot`/`claude`/`codex`).
- The requested model was never printed to stderr — it was only recorded in the structured `--log-file` run log.

(The args are intentionally summarized as a count to avoid leaking prompt text / API keys; the model itself isn't sensitive.)

## Change

In `pkg/engine/engine.go`:
- Add an `engineID` parameter to `logEngineInvoke` so the canonical engine is logged even when the spawned process is `node`.
- Add `model=...` to the stderr line, showing the requested model or `(engine default)` when no override was passed.
- The structured JSONL log gains a matching `engine` field alongside the existing `model`.

The stderr line now reads:

```
[threat-detect] engine invoke: engine=codex model=(engine default) command=node (/opt/hostedtoolcache/node/24.18.0/x64/bin/node) args=13
```

## Testing

- `make fmt lint build`
- `go test ./...` (all packages pass)