### PR TITLE
fix(engine): resolve copilot 'auto' model alias in AWF detection

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -131,6 +131,7 @@ type copilotEngine struct {
 
 func (e *copilotEngine) Analyze(ctx context.Context, prompt string, opts AnalyzeOptions) (string, error) {
 	env := copilotEnv(e.model)
+	env = append(env, copilotHarnessAwfConfigEnv()...)
 	toolEnv, cleanup, err := maybeProvisionResultTool(opts.ResultSinkPath)
 	if err != nil {
 		return "", err
@@ -280,6 +281,45 @@ func copilotEnv(model string) []string {
 		return nil
 	}
 	return []string{"COPILOT_MODEL=" + model}
+}
+
+// copilotHarnessDefaultAwfConfigPath is where the gh-aw copilot harness looks
+// for the AWF config (which carries the model alias map) when
+// GH_AW_AWF_CONFIG_PATH is unset.
+const copilotHarnessDefaultAwfConfigPath = "/tmp/gh-aw/awf-config.json"
+
+// copilotHarnessAwfConfigEnv points the gh-aw copilot harness at the AWF config
+// file so it can resolve model aliases (e.g. "auto") against the api-proxy
+// model map before spawning the Copilot CLI.
+//
+// Under AWF, the gh-aw agent job copies awf-config.json to the harness's default
+// location (/tmp/gh-aw/awf-config.json), but the standalone detection job does
+// not — it only mounts the config at $RUNNER_TEMP/gh-aw/awf-config.json. Without
+// the alias map the harness passes the literal alias (e.g. COPILOT_MODEL=auto)
+// straight to the Copilot CLI, which rejects it with
+// "400 The requested model is not supported". Exporting GH_AW_AWF_CONFIG_PATH so
+// the harness finds the mounted config restores the same alias resolution the
+// agent job performs.
+//
+// It returns nil when GH_AW_AWF_CONFIG_PATH is already set, when the harness
+// default path exists (the harness will find it there), or when no mounted
+// config can be located.
+func copilotHarnessAwfConfigEnv() []string {
+	if strings.TrimSpace(os.Getenv("GH_AW_AWF_CONFIG_PATH")) != "" {
+		return nil
+	}
+	if _, err := os.Stat(copilotHarnessDefaultAwfConfigPath); err == nil {
+		return nil
+	}
+	runnerTemp := strings.TrimSpace(os.Getenv("RUNNER_TEMP"))
+	if runnerTemp == "" {
+		return nil
+	}
+	candidate := filepath.Join(runnerTemp, "gh-aw", "awf-config.json")
+	if _, err := os.Stat(candidate); err != nil {
+		return nil
+	}
+	return []string{"GH_AW_AWF_CONFIG_PATH=" + candidate}
 }
 
 func claudeArgs(model string, allowBash bool) []string {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -183,6 +183,40 @@ func TestEngineCommandArgs(t *testing.T) {
 		}
 	})
 
+	t.Run("copilot harness awf config env points at mounted config", func(t *testing.T) {
+		t.Setenv("GH_AW_AWF_CONFIG_PATH", "")
+		runnerTemp := t.TempDir()
+		t.Setenv("RUNNER_TEMP", runnerTemp)
+		configPath := filepath.Join(runnerTemp, "gh-aw", "awf-config.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		got := copilotHarnessAwfConfigEnv()
+		want := []string{"GH_AW_AWF_CONFIG_PATH=" + configPath}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("copilotHarnessAwfConfigEnv() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("copilot harness awf config env respects existing override", func(t *testing.T) {
+		t.Setenv("GH_AW_AWF_CONFIG_PATH", "/custom/awf-config.json")
+		t.Setenv("RUNNER_TEMP", t.TempDir())
+		if got := copilotHarnessAwfConfigEnv(); got != nil {
+			t.Fatalf("copilotHarnessAwfConfigEnv() = %#v, want nil", got)
+		}
+	})
+
+	t.Run("copilot harness awf config env nil when no config mounted", func(t *testing.T) {
+		t.Setenv("GH_AW_AWF_CONFIG_PATH", "")
+		t.Setenv("RUNNER_TEMP", t.TempDir())
+		if got := copilotHarnessAwfConfigEnv(); got != nil {
+			t.Fatalf("copilotHarnessAwfConfigEnv() = %#v, want nil", got)
+		}
+	})
+
 	t.Run("claude", func(t *testing.T) {
 		got := claudeArgs("claude-sonnet-4.6", false)
 		want := []string{"--print", "--verbose", "--output-format", "stream-json", "--model", "claude-sonnet-4.6", "-"}

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -232,6 +232,8 @@ treats a missing verdict as a recoverable `parse_error` and proceeds.
 
 This keeps the standalone detector consistent with the model `gh-aw` configures for the harness-driven detection path. Codex has no native model environment variable and relies solely on the detection variable.
 
+**TD-22b**: When the Copilot engine runs via the `gh-aw` Copilot harness and the resolved model is a `gh-aw` model alias (e.g. `auto`), the detector MUST make the AWF configuration (which carries the api-proxy model alias map) discoverable by the harness so the alias is resolved to a concrete model before the Copilot CLI is invoked. When `GH_AW_AWF_CONFIG_PATH` is unset and the harness default location (`/tmp/gh-aw/awf-config.json`) is absent, the detector MUST point the harness at the AWF config mounted at `$RUNNER_TEMP/gh-aw/awf-config.json` when that file exists. Without this, the harness forwards the literal alias to the Copilot CLI, which rejects it (`400 The requested model is not supported`).
+
 **TD-23**: AI engine authentication variables MUST be treated as runtime-only configuration. They MUST NOT be required for parser, prompt building, unit test, or binary smoke test execution.
 
 The implementation MAY pass through engine-specific authentication variables required by the selected CLI, including:


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KYT641N0ZM5BN8R3WP4AP7TS)

## Problem

The latest Copilot standalone smoke run failed in the **detection** job with:

```
400 The requested model is not supported.
[copilot-harness] attempt 1: refreshed awf-reflect does not include model 'auto' — treating as non-retryable
THREAT_DETECTION_STATUS: reason=engine_error exit=2
```

The **agent** job in the same run resolved the model fine:

```
[copilot-harness] copilot model alias resolution: 'auto' -> 'claude-sonnet-5'
```

## Root cause

Under AWF, the Copilot CLI runs via the gh-aw copilot harness, which resolves gh-aw model aliases (e.g. `auto`) against the AWF api-proxy model map in `awf-config.json` (`apiProxy.models`) before spawning the CLI.

- The **agent** job copies the config to the harness default location: `cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json`.
- The **detection** job only mounts it at `$RUNNER_TEMP/gh-aw/awf-config.json` and never copies it to the default path.

So the harness couldn't find the alias map, never resolved `auto`, and forwarded `COPILOT_MODEL=auto` verbatim to the Copilot CLI — which rejected it with a 400.

## Fix

`threat-detect` now exports `GH_AW_AWF_CONFIG_PATH` pointing at the mounted `$RUNNER_TEMP/gh-aw/awf-config.json` for the Copilot harness when:

- `GH_AW_AWF_CONFIG_PATH` is not already set, **and**
- the harness default `/tmp/gh-aw/awf-config.json` does not exist, **and**
- the mounted config file is present.

This restores the same alias resolution the agent job performs, so `auto` resolves to a concrete model before the CLI is invoked.

## Changes

- `pkg/engine/engine.go`: add `copilotHarnessAwfConfigEnv()` and wire it into `copilotEngine.Analyze`.
- `pkg/engine/engine_test.go`: unit tests for the mounted-config, existing-override, and no-config cases.
- `specs/threat-detection-spec.md`: new normative clause **TD-22b** documenting the AWF config passthrough for alias resolution.

## Validation

`make fmt lint build test` — all green.