### PR TITLE
fix(conclude): map THREAT_DETECTION_STATUS reason for missing result files

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,21 @@ and `GH_AW_DETECTION_REASON` to `GITHUB_ENV`. It reads these environment inputs:
 - `GH_AW_DETECTION_CONTINUE_ON_ERROR` — anything other than `"false"` is warn mode
 - `DETECTION_AGENTIC_EXECUTION_OUTCOME` — `"failure"` makes `agent_failure`/`parse_error` hard-fail
 
-A missing result file reports `agent_failure` ("Detection result file not found
-at: <path>"), a malformed file reports `parse_error`, and detected threats report
-`threat_detected`. There is no log-scraping fallback: if the file is absent, the
-step fails loudly.
+A malformed (readable but unparseable) result file always reports `parse_error`,
+and detected threats report `threat_detected`. When the result file is missing,
+`conclude` consults the detection run's captured log (`--detection-log <path>`,
+default `<result-file-dir>/detection.log`) for the terminal
+`THREAT_DETECTION_STATUS: reason=<reason> exit=<code>` line and maps it onto the
+host-side reason:
+
+| status reason | host-side `reason` |
+|---|---|
+| `invalid_report_exhausted` | `parse_error` |
+| `output_write_error` | `parse_error` |
+| `engine_error` | `agent_failure` |
+| `cancelled` | `agent_failure` |
+| `config_error` | `agent_failure` |
+| absent / unrecognized / log unreadable | `agent_failure` ("Detection result file not found at: <path>") |
 
 ### AI Credits and Token Usage
 

--- a/cmd/threat-detect/conclude.go
+++ b/cmd/threat-detect/conclude.go
@@ -204,11 +204,16 @@ func lastDetectionStatusReason(path string) string {
 		if idx < 0 {
 			continue
 		}
+		// Reset per status line so a malformed/truncated terminal line (no
+		// reason= token) clears any reason parsed from an earlier line,
+		// rather than leaving it stale.
+		lineReason := ""
 		for _, tok := range strings.Fields(line[idx+len(statusPrefix):]) {
 			if r, ok := strings.CutPrefix(tok, "reason="); ok {
-				reason = r
+				lineReason = r
 			}
 		}
+		reason = lineReason
 	}
 	return reason
 }

--- a/cmd/threat-detect/conclude.go
+++ b/cmd/threat-detect/conclude.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/github/gh-aw-threat-detection/pkg/detector"
@@ -33,6 +34,27 @@ const (
 // the detector via --output and surfaced through the AWF read-write mount.
 const defaultConcludeResultFile = "/tmp/gh-aw/threat-detection/detection_result.json"
 
+// defaultDetectionLogName is the conventional filename for the detection run's
+// captured log, sitting alongside the result file. It is a plain-text capture
+// of the run's stderr (which includes the terminal THREAT_DETECTION_STATUS:
+// line emitted by emitStatus in main.go), not the JSONL --log-file trace.
+const defaultDetectionLogName = "detection.log"
+
+// detectionStatusReasonMap maps the terminal status-line reason emitted by a
+// detection run (main.go's reasonXxx constants) onto the gh-aw job-output
+// reason contract consumed by threat_detection_warning.cjs's
+// isToolingFailureReason (only "agent_failure" and "parse_error" are
+// tooling-failure reasons; result_recorded never reaches this path because a
+// recorded verdict always leaves a readable result file). Status reasons are
+// intentionally reused from main.go rather than restated as string literals.
+var detectionStatusReasonMap = map[string]string{
+	reasonInvalidReportExhausted: "parse_error",   // engine ran but never recorded a valid verdict
+	reasonOutputWriteError:       "parse_error",   // verdict obtained but writing the result failed
+	reasonEngineError:            "agent_failure", // engine subprocess itself failed
+	reasonCancelled:              "agent_failure", // run was interrupted before a verdict
+	reasonConfigError:            "agent_failure", // setup/validation failed before the engine ran
+}
+
 // runConclude implements the "conclude" subcommand. It reads the structured
 // detection verdict produced by the detection run, evaluates it against the
 // gh-aw job-output contract (conclusion/success/reason plus the exported
@@ -42,12 +64,17 @@ func runConclude(args []string) int {
 	fs := flag.NewFlagSet("conclude", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	var resultFile string
+	var detectionLog string
 	fs.StringVar(&resultFile, "result-file", defaultConcludeResultFile, "Path to the structured detection_result.json verdict file")
+	fs.StringVar(&detectionLog, "detection-log", "", "Path to the detection run's captured log, consulted to refine agent_failure/parse_error when the result file is missing (default: <result-file dir>/detection.log)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return concludeExitProceed
 		}
 		return concludeExitFail
+	}
+	if detectionLog == "" {
+		detectionLog = filepath.Join(filepath.Dir(resultFile), defaultDetectionLogName)
 	}
 
 	c := &concluder{
@@ -56,6 +83,7 @@ func runConclude(args []string) int {
 		executionFailed: os.Getenv("DETECTION_AGENTIC_EXECUTION_OUTCOME") == "failure",
 		githubOutput:    os.Getenv("GITHUB_OUTPUT"),
 		githubEnv:       os.Getenv("GITHUB_ENV"),
+		detectionLog:    detectionLog,
 		stdout:          os.Stdout,
 	}
 	return c.run(resultFile)
@@ -71,6 +99,7 @@ type concluder struct {
 
 	githubOutput string // path of $GITHUB_OUTPUT (may be empty)
 	githubEnv    string // path of $GITHUB_ENV (may be empty)
+	detectionLog string // path of the detection run's captured log (may be empty or unreadable)
 	stdout       io.Writer
 }
 
@@ -89,17 +118,21 @@ func (c *concluder) run(resultFile string) int {
 	// Step 2 — locate and read the structured verdict file. A missing or
 	// otherwise unreadable file (not-exist, permission/IO error, or a TOCTOU
 	// where the file is removed mid-read) means the detection run never produced
-	// a readable verdict, which is a system-side agent failure (ERR_SYSTEM). Only
-	// a file that is readable but whose contents are empty or malformed is a
-	// parse error (ERR_PARSE).
+	// a readable verdict. detectionFailureReason refines this into agent_failure
+	// or parse_error using the detection run's captured THREAT_DETECTION_STATUS:
+	// line when available, defaulting to agent_failure/ERR_SYSTEM otherwise. Only
+	// a file that is readable but whose contents are empty or malformed is
+	// unconditionally a parse error (ERR_PARSE).
 	result, err := detector.ReadResultFile(resultFile)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return c.fail("agent_failure", fmt.Sprintf("%s: ❌ Detection result file not found at: %s", errCodeSystem, resultFile))
+			reason, code := c.detectionFailureReason()
+			return c.fail(reason, fmt.Sprintf("%s: ❌ Detection result file not found at: %s", code, resultFile))
 		}
 		var pathErr *fs.PathError
 		if errors.As(err, &pathErr) {
-			return c.fail("agent_failure", fmt.Sprintf("%s: ❌ Detection result file unreadable at %s: %v", errCodeSystem, resultFile, err))
+			reason, code := c.detectionFailureReason()
+			return c.fail(reason, fmt.Sprintf("%s: ❌ Detection result file unreadable at %s: %v", code, resultFile, err))
 		}
 		return c.fail("parse_error", fmt.Sprintf("%s: ❌ Failed to parse detection result file %s: %v", errCodeParse, resultFile, err))
 	}
@@ -130,6 +163,54 @@ func (c *concluder) run(resultFile string) int {
 	c.setOutput("reason", "")
 	c.exportVariable("GH_AW_DETECTION_REASON", "")
 	return concludeExitProceed
+}
+
+// detectionFailureReason returns the gh-aw reason (and matching error-code
+// prefix) to report when the structured result file is missing or unreadable.
+// It defaults to "agent_failure"/ERR_SYSTEM (no verdict was recorded at all),
+// but first consults the detection run's captured log for a terminal
+// THREAT_DETECTION_STATUS: line so a parse failure (invalid_report_exhausted,
+// output_write_error) is distinguished from a genuine infrastructure failure
+// (engine_error, cancelled, config_error), per TD-20b.
+func (c *concluder) detectionFailureReason() (reason, errCode string) {
+	if statusReason := lastDetectionStatusReason(c.detectionLog); statusReason != "" {
+		if mapped, ok := detectionStatusReasonMap[statusReason]; ok {
+			code := errCodeSystem
+			if mapped == "parse_error" {
+				code = errCodeParse
+			}
+			return mapped, code
+		}
+	}
+	return "agent_failure", errCodeSystem
+}
+
+// lastDetectionStatusReason reads path (the detection run's captured log) and
+// returns the reason field of the last THREAT_DETECTION_STATUS: line found, or
+// "" if the file cannot be read or no such line is present. Only the last
+// occurrence is used because a retried run may have emitted earlier lines from
+// unrelated invocations captured in the same file.
+func lastDetectionStatusReason(path string) string {
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	reason := ""
+	for _, line := range strings.Split(string(data), "\n") {
+		idx := strings.Index(line, statusPrefix)
+		if idx < 0 {
+			continue
+		}
+		for _, tok := range strings.Fields(line[idx+len(statusPrefix):]) {
+			if r, ok := strings.CutPrefix(tok, "reason="); ok {
+				reason = r
+			}
+		}
+	}
+	return reason
 }
 
 // fail records a failure verdict and decides whether to fail closed. It mirrors

--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -351,6 +351,40 @@ func TestDetectionFailureReasonUsesLastStatusLine(t *testing.T) {
 	}
 }
 
+// TestDetectionFailureReasonTerminalLineWithoutReasonResetsCandidate verifies
+// that a terminal THREAT_DETECTION_STATUS: line lacking a reason= token (e.g.
+// truncated or malformed) does not let an earlier line's reason leak through
+// as a stale candidate; per TD-20b an absent/unrecognized reason on the
+// terminal line falls back to agent_failure.
+func TestDetectionFailureReasonTerminalLineWithoutReasonResetsCandidate(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "detection.log")
+	content := "THREAT_DETECTION_STATUS: reason=invalid_report_exhausted exit=2\n" +
+		"THREAT_DETECTION_STATUS: exit=2\n" // terminal line has no reason= token
+	if err := os.WriteFile(logPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	outPath := filepath.Join(dir, "out")
+	envPath := filepath.Join(dir, "env")
+	resultFile := filepath.Join(dir, "detection_result.json")
+
+	var stdout bytes.Buffer
+	c := &concluder{
+		runDetection: "true",
+		warnMode:     false,
+		githubOutput: outPath,
+		githubEnv:    envPath,
+		detectionLog: logPath,
+		stdout:       &stdout,
+	}
+	c.run(resultFile)
+	outputs := parseKV(t, outPath)
+	if got := outputs["reason"]; got != "agent_failure" {
+		t.Errorf("reason output = %q, want %q (stale reason from earlier line must not leak through)", got, "agent_failure")
+	}
+}
+
 // TestDetectionFailureReasonWithoutLogFallsBackToAgentFailure verifies that a
 // missing or absent detection log preserves the pre-existing agent_failure
 // default rather than erroring.

--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -267,6 +267,143 @@ func TestConcludeThreatMessageEscaped(t *testing.T) {
 	}
 }
 
+// TestDetectionFailureReasonMapping verifies every THREAT_DETECTION_STATUS
+// reason from the detection run's captured log maps to the correct gh-aw
+// reason when the structured result file is missing, per the table in issue
+// #693 and specs/threat-detection-spec.md TD-20b.
+func TestDetectionFailureReasonMapping(t *testing.T) {
+	tests := []struct {
+		statusReason string // reason= value in the captured THREAT_DETECTION_STATUS line
+		wantReason   string // gh-aw reason expected on the conclude output
+	}{
+		{"invalid_report_exhausted", "parse_error"},
+		{"output_write_error", "parse_error"},
+		{"engine_error", "agent_failure"},
+		{"cancelled", "agent_failure"},
+		{"config_error", "agent_failure"},
+		{"result_recorded", "agent_failure"}, // not a failure reason; falls back to default
+		{"some_future_unknown_reason", "agent_failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statusReason, func(t *testing.T) {
+			dir := t.TempDir()
+			logPath := filepath.Join(dir, "detection.log")
+			logLine := "THREAT_DETECTION_STATUS: reason=" + tt.statusReason + " exit=2\n"
+			if err := os.WriteFile(logPath, []byte(logLine), 0o600); err != nil {
+				t.Fatalf("WriteFile error = %v", err)
+			}
+
+			outPath := filepath.Join(dir, "out")
+			envPath := filepath.Join(dir, "env")
+			resultFile := filepath.Join(dir, "detection_result.json") // deliberately absent
+
+			var stdout bytes.Buffer
+			c := &concluder{
+				runDetection: "true",
+				warnMode:     false,
+				githubOutput: outPath,
+				githubEnv:    envPath,
+				detectionLog: logPath,
+				stdout:       &stdout,
+			}
+			code := c.run(resultFile)
+			if code != concludeExitFail {
+				t.Fatalf("exit code = %d, want %d (stdout: %s)", code, concludeExitFail, stdout.String())
+			}
+			outputs := parseKV(t, outPath)
+			if got := outputs["reason"]; got != tt.wantReason {
+				t.Errorf("reason output = %q, want %q", got, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestDetectionFailureReasonUsesLastStatusLine verifies that when the captured
+// log contains multiple THREAT_DETECTION_STATUS lines (e.g. from a retried
+// invocation), only the last one is consulted.
+func TestDetectionFailureReasonUsesLastStatusLine(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "detection.log")
+	content := "THREAT_DETECTION_STATUS: reason=engine_error exit=2\n" +
+		"THREAT_DETECTION_STATUS: reason=invalid_report_exhausted exit=2\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	outPath := filepath.Join(dir, "out")
+	envPath := filepath.Join(dir, "env")
+	resultFile := filepath.Join(dir, "detection_result.json")
+
+	var stdout bytes.Buffer
+	c := &concluder{
+		runDetection: "true",
+		warnMode:     false,
+		githubOutput: outPath,
+		githubEnv:    envPath,
+		detectionLog: logPath,
+		stdout:       &stdout,
+	}
+	c.run(resultFile)
+	outputs := parseKV(t, outPath)
+	if got := outputs["reason"]; got != "parse_error" {
+		t.Errorf("reason output = %q, want %q (should use last status line)", got, "parse_error")
+	}
+}
+
+// TestDetectionFailureReasonWithoutLogFallsBackToAgentFailure verifies that a
+// missing or absent detection log preserves the pre-existing agent_failure
+// default rather than erroring.
+func TestDetectionFailureReasonWithoutLogFallsBackToAgentFailure(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out")
+	envPath := filepath.Join(dir, "env")
+	resultFile := filepath.Join(dir, "detection_result.json")
+
+	var stdout bytes.Buffer
+	c := &concluder{
+		runDetection: "true",
+		warnMode:     false,
+		githubOutput: outPath,
+		githubEnv:    envPath,
+		detectionLog: filepath.Join(dir, "does-not-exist.log"),
+		stdout:       &stdout,
+	}
+	c.run(resultFile)
+	outputs := parseKV(t, outPath)
+	if got := outputs["reason"]; got != "agent_failure" {
+		t.Errorf("reason output = %q, want %q", got, "agent_failure")
+	}
+}
+
+// TestRunConcludeDefaultsDetectionLogPath verifies that --detection-log, when
+// not set, defaults to detection.log next to the result file, and that its
+// status line correctly refines the reported reason.
+func TestRunConcludeDefaultsDetectionLogPath(t *testing.T) {
+	dir := t.TempDir()
+	resultFile := filepath.Join(dir, "detection_result.json") // absent
+	logPath := filepath.Join(dir, "detection.log")
+	if err := os.WriteFile(logPath, []byte("THREAT_DETECTION_STATUS: reason=invalid_report_exhausted exit=2\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	outPath := filepath.Join(dir, "out")
+	envPath := filepath.Join(dir, "env")
+
+	t.Setenv("RUN_DETECTION", "true")
+	t.Setenv("GH_AW_DETECTION_CONTINUE_ON_ERROR", "false")
+	t.Setenv("GITHUB_OUTPUT", outPath)
+	t.Setenv("GITHUB_ENV", envPath)
+
+	code := runConclude([]string{"--result-file", resultFile})
+	if code != concludeExitFail {
+		t.Fatalf("runConclude() = %d, want %d", code, concludeExitFail)
+	}
+	outputs := parseKV(t, outPath)
+	if got := outputs["reason"]; got != "parse_error" {
+		t.Fatalf("reason = %q, want %q", got, "parse_error")
+	}
+}
+
 func TestRunConcludeReadsEnv(t *testing.T) {
 	dir := t.TempDir()
 	resultFile := writeResultFixture(t, safeVerdict)

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -184,13 +184,27 @@ A failure to open the log file MUST be treated as a configuration error.
 result file written by a prior detection run and emits the host-side job-output
 contract (`conclusion`, `reason`, `success`) consumed by the parent orchestrator.
 The verdict crosses the AWF sandbox boundary as a file (written to a read-write
-mount), not via log scraping. When the result file is missing the subcommand MUST
-report a clear `agent_failure` (e.g. "Detection result file not found at: <path>");
-a malformed file MUST report `parse_error`; detected threats MUST report
-`threat_detected`. In warn mode (`GH_AW_DETECTION_CONTINUE_ON_ERROR != "false"`)
-non-mandatory failures MUST surface as warnings without failing the job, except
-that `agent_failure` and `parse_error` MUST hard-fail when the detection execution
-step itself failed.
+mount), not via log scraping. When the result file is missing, `conclude` MUST
+consult the detection run's captured log (`--detection-log <path>`, default
+`<result-file-dir>/detection.log`) for the terminal `THREAT_DETECTION_STATUS:`
+line (per TD-20a) and map its `reason=` value onto the host-side `reason` per the
+following table, defaulting to `agent_failure` when the log is absent, unreadable,
+or contains no status line:
+
+| status reason | host-side `reason` |
+|---|---|
+| `invalid_report_exhausted` | `parse_error` |
+| `output_write_error` | `parse_error` |
+| `engine_error` | `agent_failure` |
+| `cancelled` | `agent_failure` |
+| `config_error` | `agent_failure` |
+| absent / unrecognized | `agent_failure` |
+
+A malformed (readable but unparseable) result file MUST unconditionally report
+`parse_error`; detected threats MUST report `threat_detected`. In warn mode
+(`GH_AW_DETECTION_CONTINUE_ON_ERROR != "false"`) non-mandatory failures MUST
+surface as warnings without failing the job, except that `agent_failure` and
+`parse_error` MUST hard-fail when the detection execution step itself failed.
 
 ### 8.3 Exit Codes
 

--- a/specs/usage-spec.md
+++ b/specs/usage-spec.md
@@ -199,12 +199,17 @@ environment inputs consumed by `conclude`:
 | `GH_AW_DETECTION_CONTINUE_ON_ERROR` | Anything other than `"false"` selects warn mode |
 | `DETECTION_AGENTIC_EXECUTION_OUTCOME` | `"failure"` makes `agent_failure`/`parse_error` hard-fail |
 
+A host MAY also pass `--detection-log <path>` (default `<result-file-dir>/detection.log`)
+so `conclude` can refine a missing-result-file outcome into `agent_failure` or
+`parse_error` from the run's captured `THREAT_DETECTION_STATUS:` line, per TD-20b.
+
 **U-20**: The host MUST honor the `conclude` outcomes: a missing result file
-reports `agent_failure`, a malformed result file reports `parse_error`, and a
-detected threat reports `threat_detected`. In warn mode, non-mandatory failures
-MUST surface as warnings without failing the job, except that `agent_failure`
-and `parse_error` MUST hard-fail when the detection execution step itself failed
-(per TD-20b).
+reports `agent_failure` or `parse_error` (refined from the detection log per
+TD-20b, defaulting to `agent_failure`), a malformed result file always reports
+`parse_error`, and a detected threat reports `threat_detected`. In warn mode,
+non-mandatory failures MUST surface as warnings without failing the job, except
+that `agent_failure` and `parse_error` MUST hard-fail when the detection execution
+step itself failed (per TD-20b).
 
 ### 6.1 Exit codes and status line
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ714XR3ZXWPYNCMEV4SBXMJ)

Fixes #693.

`threat-detect conclude` previously hardcoded `agent_failure` whenever the structured `detection_result.json` was missing, discarding the richer terminal `THREAT_DETECTION_STATUS: reason=<reason> exit=<code>` signal emitted to stderr (and, when `--log-file` is used, mirrored in the JSONL run log). This meant `invalid_report_exhausted` (the engine ran but never produced a parseable verdict) was misreported as an engine crash rather than the semantically-correct `parse_error`, and `config_error` misconfiguration was hidden behind the same generic message.

## Changes

- New `--detection-log <path>` flag on `conclude` (default `<result-file-dir>/detection.log`), pointing at the detection run's captured log.
- When the result file is missing/unreadable, `conclude` now parses the *last* `THREAT_DETECTION_STATUS:` line in that log and maps it onto the gh-aw `reason` contract:

  | status reason | gh-aw `reason` |
  |---|---|
  | `invalid_report_exhausted` | `parse_error` |
  | `output_write_error` | `parse_error` |
  | `engine_error` | `agent_failure` |
  | `cancelled` | `agent_failure` |
  | `config_error` | `agent_failure` |
  | absent / unrecognized / log unreadable | `agent_failure` (unchanged default) |

- The `ERR_SYSTEM`/`ERR_PARSE` message prefix now matches the resolved reason.
- A readable-but-malformed result file still unconditionally reports `parse_error` (unchanged).
- Added unit tests covering every status→reason mapping, last-line precedence when multiple status lines are captured, log-absent fallback, and the default `--detection-log` path derivation.
- Updated `specs/threat-detection-spec.md` (TD-20b), `specs/usage-spec.md` (U-17–U-20), and `README.md` with the new flag and mapping table.

## Not included (follow-ups from the issue)

- Moving missing-result-file handling out of `conclude_threat_detection.sh` entirely (item 2) — that shell script lives in `gh-aw`, not this repo.
- Proposing a new upstream `config_error` gh-aw reason (item 3) — left as a future upstream discussion; `config_error` currently maps to `agent_failure` per the table above.

## Testing

- `make fmt lint build test` — all pass.
- New tests: `TestDetectionFailureReasonMapping` (parameterized over every status reason), `TestDetectionFailureReasonUsesLastStatusLine`, `TestDetectionFailureReasonWithoutLogFallsBackToAgentFailure`, `TestRunConcludeDefaultsDetectionLogPath`.