### PR TITLE
test(conclude): expand conformance matrix for gh-aw-threat-detection#694

### DIFF
--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -153,6 +153,66 @@ func TestConcludeContract(t *testing.T) {
 			wantSuccess:     "false",
 			wantReason:      "parse_error",
 		},
+		// --- Remaining matrix combinations from
+		// {RUN_DETECTION} x {result file present/absent/malformed} x {warn/strict} x
+		// {execution outcome} (gh-aw-threat-detection#694). The cases above cover the
+		// primary decision paths; these fill in the combinations that exercise
+		// mustFail's scope (agent_failure/parse_error only, never threat_detected) and
+		// confirm executionFailed is inert on the success path.
+		{
+			name:           "success on safe verdict is unaffected by warn mode",
+			runDetection:   "true",
+			warnMode:       true,
+			resultContent:  safeVerdict,
+			wantExit:       concludeExitProceed,
+			wantConclusion: "success",
+			wantSuccess:    "true",
+			wantReason:     "",
+		},
+		{
+			name:            "success on safe verdict is unaffected by executionFailed",
+			runDetection:    "true",
+			warnMode:        false,
+			executionFailed: true,
+			resultContent:   safeVerdict,
+			wantExit:        concludeExitProceed,
+			wantConclusion:  "success",
+			wantSuccess:     "true",
+			wantReason:      "",
+		},
+		{
+			name:            "threat_detected warns even when execution failed (mustFail excludes threat_detected)",
+			runDetection:    "true",
+			warnMode:        true,
+			executionFailed: true,
+			resultContent:   threatVerdict,
+			wantExit:        concludeExitProceed,
+			wantConclusion:  "warning",
+			wantSuccess:     "false",
+			wantReason:      "threat_detected",
+		},
+		{
+			name:            "malformed file warns when execution succeeded",
+			runDetection:    "true",
+			warnMode:        true,
+			executionFailed: false,
+			resultContent:   "{not json",
+			wantExit:        concludeExitProceed,
+			wantConclusion:  "warning",
+			wantSuccess:     "false",
+			wantReason:      "parse_error",
+		},
+		{
+			name:            "missing file fails closed in strict mode regardless of execution outcome",
+			runDetection:    "true",
+			warnMode:        false,
+			executionFailed: true,
+			resultMissing:   true,
+			wantExit:        concludeExitFail,
+			wantConclusion:  "failure",
+			wantSuccess:     "false",
+			wantReason:      "agent_failure",
+		},
 	}
 
 	for _, tt := range tests {
@@ -209,29 +269,73 @@ func TestConcludeContract(t *testing.T) {
 // TestConcludeUnreadableFileIsAgentFailure verifies that an IO error reading the
 // result file (here, the path is a directory) is classified as agent_failure
 // (ERR_SYSTEM), not parse_error — unreadable files are a system-side failure,
-// while parse_error is reserved for readable-but-malformed content.
+// while parse_error is reserved for readable-but-malformed content. It also
+// completes the {warn/strict} x {execution outcome} matrix for the unreadable-file
+// path (gh-aw-threat-detection#694).
 func TestConcludeUnreadableFileIsAgentFailure(t *testing.T) {
-	dir := t.TempDir()
-	// A directory at the result path yields a non-ErrNotExist *fs.PathError from
-	// os.ReadFile, deterministically across platforms and regardless of euid.
-	resultFile := filepath.Join(dir, "detection_result.json")
-	if err := os.Mkdir(resultFile, 0o755); err != nil {
-		t.Fatalf("Mkdir error = %v", err)
+	tests := []struct {
+		name            string
+		warnMode        bool
+		executionFailed bool
+		wantExit        int
+		wantConclusion  string
+	}{
+		{
+			name:           "strict mode fails closed",
+			warnMode:       false,
+			wantExit:       concludeExitFail,
+			wantConclusion: "failure",
+		},
+		{
+			name:           "warn mode warns when execution succeeded",
+			warnMode:       true,
+			wantExit:       concludeExitProceed,
+			wantConclusion: "warning",
+		},
+		{
+			name:            "warn mode fails closed when execution failed (mustFail)",
+			warnMode:        true,
+			executionFailed: true,
+			wantExit:        concludeExitFail,
+			wantConclusion:  "failure",
+		},
 	}
 
-	var stdout bytes.Buffer
-	c := &concluder{
-		runDetection: "true",
-		warnMode:     false,
-		githubOutput: filepath.Join(dir, "out"),
-		githubEnv:    filepath.Join(dir, "env"),
-		stdout:       &stdout,
-	}
-	if code := c.run(resultFile); code != concludeExitFail {
-		t.Fatalf("exit code = %d, want %d (stdout: %s)", code, concludeExitFail, stdout.String())
-	}
-	if got := parseKV(t, filepath.Join(dir, "out"))["reason"]; got != "agent_failure" {
-		t.Errorf("reason output = %q, want %q", got, "agent_failure")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// A directory at the result path yields a non-ErrNotExist *fs.PathError
+			// from os.ReadFile, deterministically across platforms and regardless of
+			// euid.
+			resultFile := filepath.Join(dir, "detection_result.json")
+			if err := os.Mkdir(resultFile, 0o755); err != nil {
+				t.Fatalf("Mkdir error = %v", err)
+			}
+
+			var stdout bytes.Buffer
+			c := &concluder{
+				runDetection:    "true",
+				warnMode:        tt.warnMode,
+				executionFailed: tt.executionFailed,
+				githubOutput:    filepath.Join(dir, "out"),
+				githubEnv:       filepath.Join(dir, "env"),
+				stdout:          &stdout,
+			}
+			if code := c.run(resultFile); code != tt.wantExit {
+				t.Fatalf("exit code = %d, want %d (stdout: %s)", code, tt.wantExit, stdout.String())
+			}
+			outputs := parseKV(t, filepath.Join(dir, "out"))
+			if got := outputs["reason"]; got != "agent_failure" {
+				t.Errorf("reason output = %q, want %q", got, "agent_failure")
+			}
+			if got := outputs["conclusion"]; got != tt.wantConclusion {
+				t.Errorf("conclusion output = %q, want %q", got, tt.wantConclusion)
+			}
+			env := parseKV(t, filepath.Join(dir, "env"))
+			if got := env["GH_AW_DETECTION_REASON"]; got != "agent_failure" {
+				t.Errorf("GH_AW_DETECTION_REASON = %q, want %q", got, "agent_failure")
+			}
+		})
 	}
 }
 

--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -213,6 +213,17 @@ func TestConcludeContract(t *testing.T) {
 			wantSuccess:     "false",
 			wantReason:      "agent_failure",
 		},
+		{
+			name:            "malformed file fails closed in strict mode regardless of execution outcome",
+			runDetection:    "true",
+			warnMode:        false,
+			executionFailed: true,
+			resultContent:   "{not json",
+			wantExit:        concludeExitFail,
+			wantConclusion:  "failure",
+			wantSuccess:     "false",
+			wantReason:      "parse_error",
+		},
 	}
 
 	for _, tt := range tests {
@@ -287,6 +298,13 @@ func TestConcludeUnreadableFileIsAgentFailure(t *testing.T) {
 			wantConclusion: "failure",
 		},
 		{
+			name:            "strict mode fails closed regardless of execution outcome",
+			warnMode:        false,
+			executionFailed: true,
+			wantExit:        concludeExitFail,
+			wantConclusion:  "failure",
+		},
+		{
 			name:           "warn mode warns when execution succeeded",
 			warnMode:       true,
 			wantExit:       concludeExitProceed,
@@ -331,9 +349,17 @@ func TestConcludeUnreadableFileIsAgentFailure(t *testing.T) {
 			if got := outputs["conclusion"]; got != tt.wantConclusion {
 				t.Errorf("conclusion output = %q, want %q", got, tt.wantConclusion)
 			}
+			// success=false on every fail path, warn or strict — only a clean
+			// verdict (or skip) sets success=true.
+			if got := outputs["success"]; got != "false" {
+				t.Errorf("success output = %q, want %q", got, "false")
+			}
 			env := parseKV(t, filepath.Join(dir, "env"))
 			if got := env["GH_AW_DETECTION_REASON"]; got != "agent_failure" {
 				t.Errorf("GH_AW_DETECTION_REASON = %q, want %q", got, "agent_failure")
+			}
+			if got := env["GH_AW_DETECTION_CONCLUSION"]; got != tt.wantConclusion {
+				t.Errorf("GH_AW_DETECTION_CONCLUSION = %q, want %q", got, tt.wantConclusion)
 			}
 		})
 	}


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ715HMCDQHFA6ZX8YQWBRCV)

Closes #694

## Context

Issue #694 describes a divergence between two implementations of the gh-aw job-output contract:

1. `actions/setup/sh/conclude_threat_detection.sh` — lives in **`github/gh-aw`**, not this repo.
2. `cmd/threat-detect/conclude.go` — lives in this repo.

## Findings

I verified the current state of both sides:

- **This repo (`conclude.go` + `specs/threat-detection-spec.md`) already fixes divergences (2), (3), and (4)** from the issue:
  - Every fail path (missing/unreadable/malformed file, in strict *and* warn mode) writes `reason` and `conclusion` to `$GITHUB_OUTPUT`, so a strict-mode infrastructure failure no longer renders as a generic/confusing threat message.
  - `GH_AW_DETECTION_CONCLUSION` / `GH_AW_DETECTION_REASON` are exported to `$GITHUB_ENV` on every path, including skip.
  - The `mustFail` fail-closed rule (execution failure + `agent_failure`/`parse_error`) is explicitly documented in `specs/threat-detection-spec.md` TD-20b and TD-21a, including the acknowledged divergence from gh-aw's inline path.
- **The remaining divergence lives entirely in `github/gh-aw`'s `actions/setup/sh/conclude_threat_detection.sh`**, which I fetched and confirmed still has the exact bugs from the issue (strict-mode missing-file branch exits 1 without writing `reason`/`conclusion`; no `GH_AW_DETECTION_*` env export; short-circuits before ever calling `threat-detect conclude` for the missing-file case). Fixing that requires a change in the `github/gh-aw` repo, which is out of scope for this repo/PR.

## Change in this PR

Expanded `cmd/threat-detect/conclude_test.go` to close the remaining gaps in proposed work item (4) — conformance tests covering the full matrix:

- Success verdict is unaffected by warn mode / `executionFailed`.
- `threat_detected` always warns in warn mode, even when execution failed (`mustFail` is scoped to `agent_failure`/`parse_error` only, never `threat_detected`).
- Malformed-file and unreadable-file cases are now exercised across all `{warn/strict} x {execution outcome}` combinations (previously only spot-checked in strict mode).

No behavior change to `conclude.go` — this is test-only.

## Follow-up needed (not in this repo)

File/track a corresponding fix in `github/gh-aw` for `actions/setup/sh/conclude_threat_detection.sh` to either delegate its missing-file handling to `threat-detect conclude` (simplest: always run `threat-detect conclude`, since it already handles missing/unreadable files correctly) or replicate the output/env contract fixes inline.