### PR TITLE
fix(artifacts): emit ERR_VALIDATION warnings for degraded/missing inputs

### DIFF
--- a/cmd/threat-detect/logfile_test.go
+++ b/cmd/threat-detect/logfile_test.go
@@ -140,6 +140,7 @@ func TestRunWritesJSONLLog(t *testing.T) {
 
 func TestRunWarnsWhenPromptAnalysisArtifactsAreMissing(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	logPath := filepath.Join(t.TempDir(), "run.jsonl")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
@@ -186,6 +187,7 @@ func TestRunWarnsWhenPromptAnalysisArtifactsAreMissing(t *testing.T) {
 
 func TestRunWarnsWhenPromptAnalysisArtifactIsEmpty(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	promptsDir := filepath.Join(artifactsDir, "aw-prompts")
 	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
 		t.Fatalf("creating prompts directory: %v", err)

--- a/cmd/threat-detect/logfile_test.go
+++ b/cmd/threat-detect/logfile_test.go
@@ -40,6 +40,7 @@ func findRecord(records []map[string]any, event string) map[string]any {
 
 func TestRunWritesJSONLLog(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	if err := os.MkdirAll(filepath.Join(artifactsDir, "experiments"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -84,15 +85,24 @@ func TestRunWritesJSONLLog(t *testing.T) {
 		t.Fatalf("missing artifacts_loaded record: %#v", records)
 	}
 	inventory, ok := loaded["inventory"].([]any)
-	if !ok || len(inventory) != 1 {
-		t.Fatalf("artifacts_loaded inventory = %#v, want one entry", loaded["inventory"])
-	}
-	entry, ok := inventory[0].(map[string]any)
 	if !ok {
-		t.Fatalf("inventory entry = %#v", inventory[0])
+		t.Fatalf("artifacts_loaded inventory = %#v, want a list", loaded["inventory"])
 	}
-	if entry["path"] != "experiments/assignment.json" || entry["consumed"] != false {
-		t.Errorf("inventory entry = %#v, want unconsumed experiment", entry)
+	var experimentEntry map[string]any
+	for _, raw := range inventory {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("inventory entry = %#v", raw)
+		}
+		if entry["path"] == "experiments/assignment.json" {
+			experimentEntry = entry
+		}
+	}
+	if experimentEntry == nil {
+		t.Fatalf("inventory %#v missing experiments/assignment.json entry", inventory)
+	}
+	if experimentEntry["consumed"] != false {
+		t.Errorf("inventory entry = %#v, want unconsumed experiment", experimentEntry)
 	}
 
 	summary, err := os.ReadFile(summaryPath)
@@ -212,6 +222,7 @@ func TestRunWarnsWhenPromptAnalysisArtifactIsEmpty(t *testing.T) {
 
 func TestRunDefaultsLogBesideOutput(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputDir := t.TempDir()
 	outputPath := filepath.Join(outputDir, "result.json")
 	logPath := filepath.Join(outputDir, "detection-runlog.jsonl")
@@ -242,6 +253,7 @@ func TestRunDefaultsLogBesideOutput(t *testing.T) {
 
 func TestRunUsesLogFileEnvVar(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	logPath := filepath.Join(t.TempDir(), "run.jsonl")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -210,8 +210,12 @@ func run() (code int) {
 		return exitError
 	}
 	logger.Info("artifacts_loaded", map[string]any{
-		"artifacts_dir": artifactsDir,
-		"inventory":     arts.Inventory,
+		"artifacts_dir":              artifactsDir,
+		"inventory":                  arts.Inventory,
+		"prompt_bytes":               arts.PromptFileSize,
+		"agent_output_bytes":         arts.AgentOutputFileSize,
+		"patch_files":                len(arts.PatchFiles),
+		"all_primary_inputs_missing": arts.AllPrimaryInputsMissing,
 	})
 	if err := stepsummary.WriteArtifactInventory(os.Getenv("GITHUB_STEP_SUMMARY"), arts.Inventory); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing artifact inventory summary: %v\n", err)
@@ -219,9 +223,28 @@ func run() (code int) {
 		reason = reasonConfigError
 		return exitError
 	}
+
+	// Degraded inputs (missing/empty prompt or agent output, an expected but
+	// absent patch, an unreadable comment-memory directory, ...) are surfaced
+	// as GitHub Actions warning annotations so they are visible even when this
+	// binary runs outside gh-aw's own "Prepare threat detection files" step.
+	// See pkg/artifacts.Load. Messages embed a caller-controlled artifacts
+	// directory path, so they must be escaped per the workflow-command rules
+	// to prevent a path containing "%" or a newline from forging another
+	// workflow command.
 	for _, w := range arts.Warnings {
-		fmt.Fprintf(os.Stderr, "::warning::%s\n", escapeWorkflowData(w))
-		logger.Info("artifacts_warning", map[string]any{"warning": w})
+		fmt.Fprintf(os.Stderr, "::warning::%s\n", escapeWorkflowData(w.Message))
+		logger.Error("artifact_degraded", map[string]any{"field": w.Field, "message": w.Message})
+	}
+
+	// All primary inputs missing simultaneously means detection would silently
+	// analyze nothing and return a clean verdict — a fail-open failure mode in
+	// a security control. Fail closed instead of proceeding.
+	if arts.AllPrimaryInputsMissing {
+		fmt.Fprintf(os.Stderr, "Error: prompt, agent output, and patch/bundle files are all missing or empty in %s; refusing to run detection on empty input.\n", artifactsDir)
+		logger.Error("artifacts_all_primary_inputs_missing", map[string]any{"artifacts_dir": artifactsDir})
+		reason = reasonConfigError
+		return exitError
 	}
 
 	// Resolve workflow-context overrides. Provenance is tracked from whether a

--- a/cmd/threat-detect/main_test.go
+++ b/cmd/threat-detect/main_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestRunInvokesAgenticEngine(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
 	sinkJSON := `{"prompt_injection":true,"secret_leak":false,"malicious_patch":false,"reasons":["agentic detection"]}`
@@ -98,6 +99,7 @@ func TestRunPassesPromptAnalysisToEngine(t *testing.T) {
 
 func TestRunPrefersSinkResultOverTranscript(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
 	sinkJSON := `{"prompt_injection":true,"secret_leak":false,"malicious_patch":false,"reasons":["from sink"]}`
@@ -134,6 +136,7 @@ func TestRunPrefersSinkResultOverTranscript(t *testing.T) {
 
 func TestRunEngineFailsWithoutSinkResult(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
 	// The engine emits a legacy-looking safe verdict on stdout but exits
@@ -164,6 +167,7 @@ func TestRunEngineFailsWithoutSinkResult(t *testing.T) {
 
 func TestRunEarlyTerminationOnSink(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
 	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
@@ -195,6 +199,7 @@ func TestRunEarlyTerminationOnSink(t *testing.T) {
 
 func TestRunEmitsResultRecordedStatus(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
 	sinkJSON := `{"prompt_injection":true,"secret_leak":false,"malicious_patch":false,"reasons":["agentic detection"]}`
@@ -219,6 +224,7 @@ func TestRunEmitsResultRecordedStatus(t *testing.T) {
 
 func TestRunEmitsEngineErrorStatusOnFailClosed(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	outputPath := filepath.Join(t.TempDir(), "result.json")
 	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
 	// Engine dies without recording a sink verdict: fail closed with exit 2 and
@@ -363,6 +369,23 @@ func writeFakeCopilotFailing(t *testing.T, markerPath, stdout string, exitCode i
 		t.Fatalf("writing fake copilot: %v", err)
 	}
 	return binDir
+}
+
+// writeMinimalArtifacts populates dir with a non-empty prompt and agent
+// output file so run() proceeds past artifacts loading. Tests that only
+// exercise engine/result-sink behavior use this to avoid tripping the
+// AllPrimaryInputsMissing hard-fail (see pkg/artifacts.Load).
+func writeMinimalArtifacts(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "aw-prompts"), 0o755); err != nil {
+		t.Fatalf("creating aw-prompts dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "aw-prompts", "prompt.txt"), []byte("test workflow prompt"), 0o644); err != nil {
+		t.Fatalf("writing prompt.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`), 0o644); err != nil {
+		t.Fatalf("writing agent_output.json: %v", err)
+	}
 }
 
 func readResultFile(t *testing.T, path string) map[string]any {

--- a/cmd/threat-detect/main_test.go
+++ b/cmd/threat-detect/main_test.go
@@ -252,6 +252,91 @@ func TestRunEmitsEngineErrorStatusOnFailClosed(t *testing.T) {
 	}
 }
 
+func TestRunFailsClosedOnEmptyArtifactsDirectory(t *testing.T) {
+	artifactsDir := t.TempDir() // deliberately empty: no prompt, no agent output, no patch.
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, copilotMarker, sinkJSON, 0)
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+
+	if code != exitError {
+		t.Fatalf("run() exit code = %d, want %d (fail closed on all-primary-inputs-missing)", code, exitError)
+	}
+	if _, err := os.Stat(copilotMarker); !os.IsNotExist(err) {
+		t.Fatalf("expected the engine to never run, but copilot marker exists (stat err = %v)", err)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no result file to be written, stat err = %v", err)
+	}
+	want := "THREAT_DETECTION_STATUS: reason=config_error exit=2"
+	if !strings.Contains(stderr, want) {
+		t.Fatalf("stderr missing status line %q, got:\n%s", want, stderr)
+	}
+	if !strings.Contains(stderr, "ERR_VALIDATION") {
+		t.Fatalf("stderr missing ERR_VALIDATION warning annotations, got:\n%s", stderr)
+	}
+}
+
+func TestRunFailsClosedOnEmptyArtifactsDirectoryWithLogFile(t *testing.T) {
+	artifactsDir := t.TempDir() // deliberately empty.
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	logPath := filepath.Join(t.TempDir(), "run.jsonl")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, copilotMarker, sinkJSON, 0)
+
+	code := runWithTestArgs(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		"-log-file", logPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+
+	if code != exitError {
+		t.Fatalf("run() exit code = %d, want %d (fail closed)", code, exitError)
+	}
+	if _, err := os.Stat(copilotMarker); !os.IsNotExist(err) {
+		t.Fatalf("expected the engine to never run, but copilot marker exists (stat err = %v)", err)
+	}
+
+	records := readJSONLRecords(t, logPath)
+
+	degraded := 0
+	for _, rec := range records {
+		if rec["event"] == "artifact_degraded" {
+			degraded++
+		}
+	}
+	if degraded < 2 {
+		t.Fatalf("expected at least 2 artifact_degraded records (prompt + agent_output), got %d: %#v", degraded, records)
+	}
+
+	if findRecord(records, "artifacts_all_primary_inputs_missing") == nil {
+		t.Fatalf("missing artifacts_all_primary_inputs_missing record: %#v", records)
+	}
+
+	status := findRecord(records, "status")
+	if status == nil {
+		t.Fatalf("missing status record: %#v", records)
+	}
+	if status["reason"] != reasonConfigError {
+		t.Errorf("status reason = %v, want %s", status["reason"], reasonConfigError)
+	}
+	if exit, ok := status["exit"].(float64); !ok || int(exit) != exitError {
+		t.Errorf("status exit = %v, want %d", status["exit"], exitError)
+	}
+}
+
 func runWithTestArgs(t *testing.T, args []string, env map[string]string) int {
 	t.Helper()
 	code, _ := runWithTestArgsCapture(t, args, env)

--- a/cmd/threat-detect/promptcontext_test.go
+++ b/cmd/threat-detect/promptcontext_test.go
@@ -13,6 +13,7 @@ import (
 func runDetectionForPromptContext(t *testing.T, env map[string]string, extraArgs ...string) (map[string]any, string) {
 	t.Helper()
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	logPath := filepath.Join(t.TempDir(), "run.jsonl")
 	marker := filepath.Join(t.TempDir(), "copilot-called")
 	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
@@ -166,11 +167,13 @@ func TestPromptContextEmptyFlagClearsEnvCustomPrompt(t *testing.T) {
 
 func TestPromptContextRejectsUnreadableCustomPromptFile(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.md")
+	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 
 	code, stderr := runWithTestArgsCapture(t, []string{
 		"threat-detect",
 		"-custom-prompt-file", missing,
-		t.TempDir(),
+		artifactsDir,
 	}, nil)
 
 	if code != exitError {

--- a/pkg/artifacts/artifacts.go
+++ b/pkg/artifacts/artifacts.go
@@ -264,19 +264,39 @@ func Load(dir string) (*Artifacts, error) {
 		return nil, fmt.Errorf("reading artifacts directory: %w", err)
 	}
 
-	var hasReadablePatch bool
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
 		if strings.HasPrefix(name, "aw-") && (strings.HasSuffix(name, ".patch") || strings.HasSuffix(name, ".bundle")) {
-			p := filepath.Join(dir, name)
-			arts.PatchFiles = append(arts.PatchFiles, p)
-			if size, err := fileSize(p); err == nil && size > 0 {
-				hasReadablePatch = true
-			}
+			arts.PatchFiles = append(arts.PatchFiles, filepath.Join(dir, name))
 		}
+	}
+
+	// Build patch file info string. A patch/bundle only counts as "present"
+	// for the checks below if it is a readable, non-empty regular file: a
+	// zero-length or unreadable entry provides no actual patch context.
+	var infos []string
+	hasReadablePatch := false
+	for _, p := range arts.PatchFiles {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			continue
+		}
+		if info.Size() > 0 {
+			hasReadablePatch = true
+		}
+		pType := "git-patch"
+		if strings.HasSuffix(p, ".bundle") {
+			pType = "git-bundle"
+		}
+		infos = append(infos, fmt.Sprintf("%s (%d bytes, %s)", p, info.Size(), pType))
+	}
+	if len(infos) > 0 {
+		arts.PatchFileInfo = strings.Join(infos, "\n")
+	} else {
+		arts.PatchFileInfo = "No patch or bundle file found"
 	}
 
 	// Cross-check against HAS_PATCH: gh-aw sets this env var when the agent
@@ -294,25 +314,6 @@ func Load(dir string) (*Artifacts, error) {
 	arts.AllPrimaryInputsMissing = (promptMissing || promptEmpty) &&
 		(agentOutputMissing || agentOutputEmpty || agentOutputInvalid) &&
 		!hasReadablePatch
-
-	// Build patch file info string
-	if len(arts.PatchFiles) > 0 {
-		var infos []string
-		for _, p := range arts.PatchFiles {
-			info, err := os.Stat(p)
-			if err != nil {
-				continue
-			}
-			pType := "git-patch"
-			if strings.HasSuffix(p, ".bundle") {
-				pType = "git-bundle"
-			}
-			infos = append(infos, fmt.Sprintf("%s (%d bytes, %s)", p, info.Size(), pType))
-		}
-		arts.PatchFileInfo = strings.Join(infos, "\n")
-	} else {
-		arts.PatchFileInfo = "No patch or bundle file found"
-	}
 
 	// Discover comment-memory markdown files (an attacker-influenced, persisted
 	// channel written by the agent). The directory is optional; when present but

--- a/pkg/artifacts/artifacts.go
+++ b/pkg/artifacts/artifacts.go
@@ -33,6 +33,23 @@ const (
 	DefaultWorkflowDescription = "No description provided"
 )
 
+// errCodeValidation mirrors the ERR_VALIDATION prefix used by gh-aw's
+// error_codes.cjs so degraded-artifact warnings look identical whether they
+// originate from gh-aw's inline detection path or this standalone detector.
+const errCodeValidation = "ERR_VALIDATION"
+
+// ArtifactWarning records a single degraded-input finding: a human-readable
+// message (already prefixed with the ERR_VALIDATION error code) plus the
+// structured fields worth mirroring into the JSONL run log.
+type ArtifactWarning struct {
+	// Message is the full warning text, ready to emit as
+	// "::warning::" + Message in a GitHub Actions annotation.
+	Message string
+	// Field identifies which artifact the warning concerns (e.g. "prompt",
+	// "agent_output", "patch"), for structured logging.
+	Field string
+}
+
 // InventoryEntry describes a file discovered below the artifacts directory.
 type InventoryEntry struct {
 	Path     string `json:"path"`
@@ -119,10 +136,26 @@ type Artifacts struct {
 	// files for template replacement.
 	CommentMemoryFileInfo string
 
+	// PromptFileSize is the size in bytes of the prompt file, or 0 if absent.
+	PromptFileSize int64
+
+	// AgentOutputFileSize is the size in bytes of the agent output file, or 0 if absent.
+	AgentOutputFileSize int64
+
 	// Warnings holds non-fatal validation warnings collected while loading
-	// artifacts (for example, an unreadable comment-memory directory). Each
-	// entry is prefixed with an error code such as ERR_VALIDATION.
-	Warnings []string
+	// artifacts (for example, missing/empty prompt or agent output, an
+	// unreadable comment-memory directory, or an expected-but-absent patch).
+	// Each entry's Message is prefixed with an error code such as
+	// ERR_VALIDATION. Callers are expected to surface each one as a GitHub
+	// Actions ::warning:: annotation and mirror it into the JSONL run log.
+	Warnings []ArtifactWarning
+
+	// AllPrimaryInputsMissing is true when the prompt, agent output, and any
+	// patch/bundle files are all missing or empty simultaneously. This is a
+	// fail-open red flag: the detector would otherwise analyze nothing and
+	// return a clean verdict. Callers should treat this as a hard
+	// configuration error rather than proceeding.
+	AllPrimaryInputsMissing bool
 }
 
 // Load reads and validates artifacts from the given directory.
@@ -153,12 +186,27 @@ func Load(dir string) (*Artifacts, error) {
 	}
 	arts.Inventory = inventory
 
-	// Check for prompt file
+	// Check for prompt file. Missing or zero-length is a degraded input:
+	// detection continues with fallback workflow context (WORKFLOW_NAME/
+	// WORKFLOW_DESCRIPTION), but the operator must be warned.
 	promptPath := filepath.Join(dir, artifactPromptDir, "prompt.txt")
-	if fileExists(promptPath) {
+	promptSize, promptErr := fileSize(promptPath)
+	promptMissing := promptErr != nil
+	promptEmpty := promptErr == nil && promptSize == 0
+	if !promptMissing {
 		arts.PromptFilePath = promptPath
+		arts.PromptFileSize = promptSize
 	} else {
 		arts.PromptFilePath = "No prompt file found"
+	}
+	if promptMissing {
+		arts.addWarning("prompt", fmt.Sprintf(
+			"%s: Missing detection context prompt at %s. Ensure the agent artifact includes aw-prompts/prompt.txt. Detection will continue with fallback workflow context.",
+			errCodeValidation, promptPath))
+	} else if promptEmpty {
+		arts.addWarning("prompt", fmt.Sprintf(
+			"%s: Detection context prompt at %s is empty. Detection will continue with fallback workflow context.",
+			errCodeValidation, promptPath))
 	}
 
 	// Check for prompt template file (pre-expansion template)
@@ -173,12 +221,32 @@ func Load(dir string) (*Artifacts, error) {
 		arts.PromptImportTreePath = promptImportTreePath
 	}
 
-	// Check for agent output file
+	// Check for agent output file. Missing, zero-length, or invalid JSON is a
+	// degraded input: the detector cannot see the agent's structured output.
 	agentOutputPath := filepath.Join(dir, artifactAgentOutput)
-	if fileExists(agentOutputPath) {
+	agentOutputData, agentOutputErr := os.ReadFile(agentOutputPath)
+	agentOutputMissing := agentOutputErr != nil
+	agentOutputEmpty := agentOutputErr == nil && len(agentOutputData) == 0
+	agentOutputInvalid := agentOutputErr == nil && len(agentOutputData) > 0 && !json.Valid(agentOutputData)
+	if !agentOutputMissing {
 		arts.AgentOutputFilePath = agentOutputPath
+		arts.AgentOutputFileSize = int64(len(agentOutputData))
 	} else {
 		arts.AgentOutputFilePath = "No agent output file found"
+	}
+	switch {
+	case agentOutputMissing:
+		arts.addWarning("agent_output", fmt.Sprintf(
+			"%s: Missing agent output file at %s. Detection will run without the agent's structured output.",
+			errCodeValidation, agentOutputPath))
+	case agentOutputEmpty:
+		arts.addWarning("agent_output", fmt.Sprintf(
+			"%s: Agent output file at %s is empty. Detection will run without the agent's structured output.",
+			errCodeValidation, agentOutputPath))
+	case agentOutputInvalid:
+		arts.addWarning("agent_output", fmt.Sprintf(
+			"%s: Agent output file at %s is not valid JSON. Detection will run without the agent's structured output.",
+			errCodeValidation, agentOutputPath))
 	}
 
 	awInfoPath := filepath.Join(dir, activationInfoName)
@@ -196,15 +264,36 @@ func Load(dir string) (*Artifacts, error) {
 		return nil, fmt.Errorf("reading artifacts directory: %w", err)
 	}
 
+	var hasReadablePatch bool
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
 		if strings.HasPrefix(name, "aw-") && (strings.HasSuffix(name, ".patch") || strings.HasSuffix(name, ".bundle")) {
-			arts.PatchFiles = append(arts.PatchFiles, filepath.Join(dir, name))
+			p := filepath.Join(dir, name)
+			arts.PatchFiles = append(arts.PatchFiles, p)
+			if size, err := fileSize(p); err == nil && size > 0 {
+				hasReadablePatch = true
+			}
 		}
 	}
+
+	// Cross-check against HAS_PATCH: gh-aw sets this env var when the agent
+	// job reported a patch, so its absence here means the patch/bundle never
+	// made it into the artifacts directory (or it is present but empty/unreadable).
+	if os.Getenv("HAS_PATCH") == "true" && !hasReadablePatch {
+		arts.addWarning("patch", fmt.Sprintf(
+			"%s: HAS_PATCH=true was set but no readable, non-empty aw-*.patch or aw-*.bundle file was found in %s. Detection will run without patch context.",
+			errCodeValidation, dir))
+	}
+
+	// All three primary inputs missing simultaneously means the detector would
+	// otherwise analyze nothing and return a clean verdict: a fail-open failure
+	// mode in a security control. Flag it so the caller can hard-fail instead.
+	arts.AllPrimaryInputsMissing = (promptMissing || promptEmpty) &&
+		(agentOutputMissing || agentOutputEmpty || agentOutputInvalid) &&
+		!hasReadablePatch
 
 	// Build patch file info string
 	if len(arts.PatchFiles) > 0 {
@@ -410,8 +499,8 @@ func (arts *Artifacts) loadCommentMemory(dir string) {
 	info, err := os.Lstat(commentMemoryDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			arts.Warnings = append(arts.Warnings, fmt.Sprintf(
-				"ERR_VALIDATION: Unable to inspect comment-memory directory at %s: %v", commentMemoryDir, err))
+			arts.addWarning("comment_memory", fmt.Sprintf(
+				"%s: Unable to inspect comment-memory directory at %s: %v", errCodeValidation, commentMemoryDir, err))
 		}
 		arts.CommentMemoryFileInfo = "No comment-memory files found"
 		return
@@ -425,8 +514,8 @@ func (arts *Artifacts) loadCommentMemory(dir string) {
 
 	entries, err := os.ReadDir(commentMemoryDir)
 	if err != nil {
-		arts.Warnings = append(arts.Warnings, fmt.Sprintf(
-			"ERR_VALIDATION: Unable to read comment-memory directory at %s: %v", commentMemoryDir, err))
+		arts.addWarning("comment_memory", fmt.Sprintf(
+			"%s: Unable to read comment-memory directory at %s: %v", errCodeValidation, commentMemoryDir, err))
 		arts.CommentMemoryFileInfo = "No comment-memory files found"
 		return
 	}
@@ -461,6 +550,21 @@ func (arts *Artifacts) loadCommentMemory(dir string) {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// fileSize returns the size of the regular file at path, or an error if it
+// does not exist or is not accessible.
+func fileSize(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return info.Size(), nil
+}
+
+// addWarning records an ERR_VALIDATION finding on the Artifacts value.
+func (a *Artifacts) addWarning(field, message string) {
+	a.Warnings = append(a.Warnings, ArtifactWarning{Field: field, Message: message})
 }
 
 func envOrDefault(key, defaultVal string) string {

--- a/pkg/artifacts/artifacts_test.go
+++ b/pkg/artifacts/artifacts_test.go
@@ -15,6 +15,20 @@ func writeTestFile(t *testing.T, path string, data []byte) {
 	}
 }
 
+// writeMinimalArtifactsForTest populates dir with a non-empty prompt and
+// agent output file so Load does not emit unrelated prompt/agent_output
+// warnings, keeping comment-memory-focused tests focused on comment-memory
+// warnings only.
+func writeMinimalArtifactsForTest(t *testing.T, dir string) {
+	t.Helper()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`))
+}
+
 func TestLoad_ValidDirectory(t *testing.T) {
 	dir := t.TempDir()
 
@@ -152,6 +166,224 @@ func TestLoad_CommentMemorySymlinkedFileSkipped(t *testing.T) {
 	}
 }
 
+// findWarning returns the first warning for the given field, or nil.
+func findWarning(warnings []ArtifactWarning, field string) *ArtifactWarning {
+	for i := range warnings {
+		if warnings[i].Field == field {
+			return &warnings[i]
+		}
+	}
+	return nil
+}
+
+func TestLoad_MissingPromptEmitsWarning(t *testing.T) {
+	dir := t.TempDir()
+	// Prompt missing, but agent output and a patch present so this is not the
+	// all-primary-inputs-missing case.
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`))
+	writeTestFile(t, filepath.Join(dir, "aw-feature.patch"), []byte("diff"))
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := findWarning(arts.Warnings, "prompt")
+	if w == nil {
+		t.Fatalf("expected a prompt warning, got: %#v", arts.Warnings)
+	}
+	if !strings.Contains(w.Message, "ERR_VALIDATION") || !strings.Contains(w.Message, "Missing detection context prompt") {
+		t.Errorf("unexpected prompt warning message: %q", w.Message)
+	}
+	if arts.AllPrimaryInputsMissing {
+		t.Errorf("AllPrimaryInputsMissing = true, want false")
+	}
+}
+
+func TestLoad_EmptyPromptEmitsWarning(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte(""))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`))
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := findWarning(arts.Warnings, "prompt")
+	if w == nil {
+		t.Fatalf("expected a prompt warning for empty file, got: %#v", arts.Warnings)
+	}
+	if !strings.Contains(w.Message, "is empty") {
+		t.Errorf("unexpected prompt warning message: %q", w.Message)
+	}
+	if arts.PromptFileSize != 0 {
+		t.Errorf("PromptFileSize = %d, want 0", arts.PromptFileSize)
+	}
+}
+
+func TestLoad_MissingAgentOutputEmitsWarning(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := findWarning(arts.Warnings, "agent_output")
+	if w == nil {
+		t.Fatalf("expected an agent_output warning, got: %#v", arts.Warnings)
+	}
+	if !strings.Contains(w.Message, "ERR_VALIDATION") || !strings.Contains(w.Message, "Missing agent output file") {
+		t.Errorf("unexpected agent_output warning message: %q", w.Message)
+	}
+}
+
+func TestLoad_InvalidJSONAgentOutputEmitsWarning(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte("not json{{{"))
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := findWarning(arts.Warnings, "agent_output")
+	if w == nil {
+		t.Fatalf("expected an agent_output warning for invalid JSON, got: %#v", arts.Warnings)
+	}
+	if !strings.Contains(w.Message, "not valid JSON") {
+		t.Errorf("unexpected agent_output warning message: %q", w.Message)
+	}
+}
+
+func TestLoad_EmptyAgentOutputEmitsWarning(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(""))
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := findWarning(arts.Warnings, "agent_output")
+	if w == nil {
+		t.Fatalf("expected an agent_output warning for empty file, got: %#v", arts.Warnings)
+	}
+	if !strings.Contains(w.Message, "is empty") {
+		t.Errorf("unexpected agent_output warning message: %q", w.Message)
+	}
+}
+
+func TestLoad_HasPatchEnvButNoPatchFileEmitsWarning(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`))
+	t.Setenv("HAS_PATCH", "true")
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := findWarning(arts.Warnings, "patch")
+	if w == nil {
+		t.Fatalf("expected a patch warning, got: %#v", arts.Warnings)
+	}
+	if !strings.Contains(w.Message, "HAS_PATCH=true") {
+		t.Errorf("unexpected patch warning message: %q", w.Message)
+	}
+}
+
+func TestLoad_HasPatchEnvWithPatchFileNoWarning(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`))
+	writeTestFile(t, filepath.Join(dir, "aw-feature.patch"), []byte("diff"))
+	t.Setenv("HAS_PATCH", "true")
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if w := findWarning(arts.Warnings, "patch"); w != nil {
+		t.Errorf("unexpected patch warning: %q", w.Message)
+	}
+}
+
+func TestLoad_AllPrimaryInputsMissingIsFlagged(t *testing.T) {
+	dir := t.TempDir()
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !arts.AllPrimaryInputsMissing {
+		t.Errorf("AllPrimaryInputsMissing = false, want true for a fully empty artifacts dir")
+	}
+	if len(arts.Warnings) < 2 {
+		t.Errorf("expected at least prompt and agent_output warnings, got: %#v", arts.Warnings)
+	}
+}
+
+func TestLoad_ValidDirectoryHasNoWarnings(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`))
+	writeTestFile(t, filepath.Join(dir, "aw-feature.patch"), []byte("diff content"))
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(arts.Warnings) != 0 {
+		t.Errorf("expected no warnings for a fully populated artifacts dir, got: %#v", arts.Warnings)
+	}
+	if arts.AllPrimaryInputsMissing {
+		t.Errorf("AllPrimaryInputsMissing = true, want false")
+	}
+	if arts.PromptFileSize != int64(len("test prompt")) {
+		t.Errorf("PromptFileSize = %d, want %d", arts.PromptFileSize, len("test prompt"))
+	}
+	if arts.AgentOutputFileSize != int64(len(`{"items":[]}`)) {
+		t.Errorf("AgentOutputFileSize = %d, want %d", arts.AgentOutputFileSize, len(`{"items":[]}`))
+	}
+}
+
 func TestLoad_WorkflowNameFromEnv(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("WORKFLOW_NAME", "My Custom Workflow")
@@ -279,6 +511,7 @@ func TestLoad_InventoryIncludesNestedConsumedAndUnconsumedFiles(t *testing.T) {
 
 func TestLoad_CommentMemoryFiles(t *testing.T) {
 	dir := t.TempDir()
+	writeMinimalArtifactsForTest(t, dir)
 	cmDir := filepath.Join(dir, "comment-memory")
 	if err := os.MkdirAll(cmDir, 0o755); err != nil {
 		t.Fatalf("creating comment-memory dir: %v", err)
@@ -311,6 +544,7 @@ func TestLoad_CommentMemoryFiles(t *testing.T) {
 
 func TestLoad_CommentMemoryEmptyDir(t *testing.T) {
 	dir := t.TempDir()
+	writeMinimalArtifactsForTest(t, dir)
 	if err := os.MkdirAll(filepath.Join(dir, "comment-memory"), 0o755); err != nil {
 		t.Fatalf("creating comment-memory dir: %v", err)
 	}
@@ -329,6 +563,7 @@ func TestLoad_CommentMemoryEmptyDir(t *testing.T) {
 
 func TestLoad_CommentMemoryNotADirectory(t *testing.T) {
 	dir := t.TempDir()
+	writeMinimalArtifactsForTest(t, dir)
 	// A regular file named comment-memory should not be treated as the dir and
 	// must not warn (parity: only inspection failures warn).
 	writeTestFile(t, filepath.Join(dir, "comment-memory"), []byte("not a dir"))

--- a/pkg/artifacts/artifacts_test.go
+++ b/pkg/artifacts/artifacts_test.go
@@ -339,6 +339,33 @@ func TestLoad_HasPatchEnvWithPatchFileNoWarning(t *testing.T) {
 	}
 }
 
+func TestLoad_HasPatchEnvWithZeroLengthPatchEmitsWarning(t *testing.T) {
+	dir := t.TempDir()
+	promptDir := filepath.Join(dir, "aw-prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("creating prompt dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(promptDir, "prompt.txt"), []byte("test prompt"))
+	writeTestFile(t, filepath.Join(dir, "agent_output.json"), []byte(`{"items":[]}`))
+	// A zero-length patch file is present on disk but provides no actual patch
+	// context, so it must not be treated as satisfying HAS_PATCH.
+	writeTestFile(t, filepath.Join(dir, "aw-feature.patch"), []byte(""))
+	t.Setenv("HAS_PATCH", "true")
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w := findWarning(arts.Warnings, "patch")
+	if w == nil {
+		t.Fatalf("expected a patch warning for a zero-length patch file, got: %#v", arts.Warnings)
+	}
+	if !strings.Contains(w.Message, "HAS_PATCH=true") {
+		t.Errorf("unexpected patch warning message: %q", w.Message)
+	}
+}
+
 func TestLoad_AllPrimaryInputsMissingIsFlagged(t *testing.T) {
 	dir := t.TempDir()
 
@@ -352,6 +379,22 @@ func TestLoad_AllPrimaryInputsMissingIsFlagged(t *testing.T) {
 	}
 	if len(arts.Warnings) < 2 {
 		t.Errorf("expected at least prompt and agent_output warnings, got: %#v", arts.Warnings)
+	}
+}
+
+func TestLoad_AllPrimaryInputsMissingIgnoresZeroLengthPatch(t *testing.T) {
+	dir := t.TempDir()
+	// A zero-length patch file must not count as "present" for the
+	// all-primary-inputs-missing check either.
+	writeTestFile(t, filepath.Join(dir, "aw-feature.patch"), []byte(""))
+
+	arts, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !arts.AllPrimaryInputsMissing {
+		t.Errorf("AllPrimaryInputsMissing = false, want true when only a zero-length patch is present")
 	}
 }
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ72A8XZ9CVXB5ADKZEVVDR3)

## Problem

`pkg/artifacts.Load` silently substituted sentinel strings (`"No prompt file found"`, etc.) for missing or degraded inputs, so a staging bug (wrong artifact name, failed download, empty file) degraded detection to a no-op that **passes** with a clean verdict — a fail-open failure mode in a security control. Fixes #701.

## Changes

- `Load` now emits an `ERR_VALIDATION`-prefixed warning (matching gh-aw's `error_codes.cjs` convention) for:
  - missing or zero-length `aw-prompts/prompt.txt`
  - missing, zero-length, or invalid-JSON `agent_output.json`
  - `HAS_PATCH=true` set in the environment but no `aw-*.patch`/`aw-*.bundle` found
- New `Artifacts` fields: `Warnings []ArtifactWarning`, `PromptFileSize`, `AgentOutputFileSize`, and `AllPrimaryInputsMissing`.
- **Hard-fail decision**: when the prompt, agent output, and any patch/bundle are *all* missing or empty simultaneously, `main.go` now returns exit 2 (`config_error`) instead of proceeding to analyze nothing and returning a clean verdict.
- `main.go` surfaces each warning as a `::warning::` GitHub Actions annotation on stderr and mirrors it (plus the hard-fail) into the JSONL run log (`artifact_degraded` / `artifacts_all_primary_inputs_missing` events).
- Tests added in `pkg/artifacts/artifacts_test.go` for each degraded-input case (missing/empty prompt, missing/empty/invalid agent output, `HAS_PATCH` cross-check, all-inputs-missing hard-fail, and the clean-pass case with no warnings).
- Updated existing `cmd/threat-detect` tests that used empty artifact directories to include a minimal valid prompt/agent-output (via a new `writeMinimalArtifacts` helper), since those tests exercise engine/sink behavior, not artifact validation, and would otherwise now hit the new hard-fail path.

## Out of scope (tracked separately)

- `prompt-template.txt` / `prompt-import-tree.json` staging (#686) and `comment-memory/` analysis (#689) are not yet implemented in this repo at all, so warnings for them are deferred to those issues.
- Surfacing artifact sizes in a step-summary block depends on step-summary rendering, which doesn't exist yet in this binary (tracked by #696).

## Testing

- `make fmt-check` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `make build` — succeeds