### PR TITLE
feat(release): publish macOS threat detector binaries

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -26,12 +26,13 @@ jobs:
           SHORT_SHA="${GITHUB_SHA:0:7}"
           VERSION="main-${SHORT_SHA}"
           mkdir -p dist
-          for GOARCH in amd64 arm64; do
-            CGO_ENABLED=0 GOOS=linux GOARCH="${GOARCH}" go build \
+          while read -r goos goarch asset; do
+            [[ -z "$goos" || "$goos" == \#* ]] && continue
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build \
               -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
-              -o "dist/threat-detect-linux-${GOARCH}" ./cmd/threat-detect
-          done
-          ( cd dist && sha256sum threat-detect-linux-amd64 threat-detect-linux-arm64 > checksums.txt )
+              -o "dist/${asset}" ./cmd/threat-detect
+          done < release-targets.txt
+          ( cd dist && sha256sum threat-detect-* > checksums.txt )
           {
             echo "short_sha=${SHORT_SHA}"
             echo "version=${VERSION}"
@@ -46,11 +47,14 @@ jobs:
           # Record every release-asset SHA-256 in the release body, mirroring the
           # tagged release workflow so downstream verification is consistent.
           notes_file="$(mktemp)"
+          mapfile -t assets < <(awk '!/^[[:space:]]*(#|$)/ { print $3 }' release-targets.txt)
+          release_files=()
           {
             echo "Unverified branch build from ${GITHUB_SHA}."
-            for asset in threat-detect-linux-amd64 threat-detect-linux-arm64; do
+            for asset in "${assets[@]}"; do
               asset_sha256="$(sha256sum "dist/${asset}" | awk '{print $1}')"
               echo "Binary asset sha256 (${asset}): sha256:${asset_sha256}"
+              release_files+=("dist/${asset}#${asset}")
             done
             echo "The Latest release continues to track the most recently promoted version."
           } > "$notes_file"
@@ -60,8 +64,7 @@ jobs:
           # promoted version) is untouched.
           gh release delete main --yes --cleanup-tag 2>/dev/null || true
           gh release create main \
-            dist/threat-detect-linux-amd64#threat-detect-linux-amd64 \
-            dist/threat-detect-linux-arm64#threat-detect-linux-arm64 \
+            "${release_files[@]}" \
             dist/checksums.txt#checksums.txt \
             --title "main (edge build ${SHORT_SHA})" \
             --notes-file "$notes_file" \
@@ -76,7 +79,7 @@ jobs:
             echo "## Published main binary"
             echo
             echo "- Rolling pre-release \`main\` updated to edge build \`${SHORT_SHA}\`"
-            echo "- Assets: \`threat-detect-linux-amd64\`, \`threat-detect-linux-arm64\` (+ \`checksums.txt\`)"
+            echo "- Assets: Linux and macOS binaries for amd64 and arm64 (+ \`checksums.txt\`)"
             echo
             echo "These are unverified branch builds. The Latest release is unaffected and continues to track the most recently promoted release."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-platform-parity.yml
+++ b/.github/workflows/release-platform-parity.yml
@@ -1,0 +1,35 @@
+name: Release Platform Parity
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - release-targets.txt
+      - scripts/check-release-platforms.sh
+      - .github/workflows/release-platform-parity.yml
+      - .github/workflows/release.yml
+      - .github/workflows/publish-main.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - release-targets.txt
+      - scripts/check-release-platforms.sh
+      - .github/workflows/release-platform-parity.yml
+      - .github/workflows/release.yml
+      - .github/workflows/publish-main.yml
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Compare release targets with gh-aw installer
+        run: scripts/check-release-platforms.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,18 +23,20 @@ jobs:
 
       - name: Build release binaries
         run: |
+          set -euo pipefail
           VERSION=${GITHUB_REF_NAME}
           mkdir -p dist
-          for GOARCH in amd64 arm64; do
-            CGO_ENABLED=0 GOOS=linux GOARCH="${GOARCH}" go build \
+          while read -r goos goarch asset; do
+            [[ -z "$goos" || "$goos" == \#* ]] && continue
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build \
               -ldflags="-s -w -X github.com/github/gh-aw-threat-detection/pkg/detector.Version=${VERSION}" \
-              -o "dist/threat-detect-linux-${GOARCH}" ./cmd/threat-detect
-          done
+              -o "dist/${asset}" ./cmd/threat-detect
+          done < release-targets.txt
 
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum threat-detect-linux-amd64 threat-detect-linux-arm64 > checksums.txt
+          sha256sum threat-detect-* > checksums.txt
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -65,13 +67,15 @@ jobs:
           # Record every release-asset SHA-256 in the release body so the promote
           # workflow can verify and pin the exact binaries that were published.
           notes_file="$(mktemp)"
-          for asset in threat-detect-linux-amd64 threat-detect-linux-arm64; do
+          mapfile -t assets < <(awk '!/^[[:space:]]*(#|$)/ { print $3 }' release-targets.txt)
+          release_files=()
+          for asset in "${assets[@]}"; do
             asset_sha256="$(sha256sum "dist/${asset}" | awk '{print $1}')"
             echo "Binary asset sha256 (${asset}): sha256:${asset_sha256}" >> "$notes_file"
+            release_files+=("dist/${asset}#${asset}")
           done
           gh release create "${GITHUB_REF_NAME}" \
-            dist/threat-detect-linux-amd64#threat-detect-linux-amd64 \
-            dist/threat-detect-linux-arm64#threat-detect-linux-arm64 \
+            "${release_files[@]}" \
             dist/checksums.txt#checksums.txt \
             --title "${GITHUB_REF_NAME}" \
             --notes-file "$notes_file" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (and other coding agents) when workin
 The component runs in two main contexts:
 
 1. **As a host CLI** (`./bin/threat-detect <artifacts-dir>`) inside a `gh-aw`-generated detection job.
-2. **As a published release-asset binary** (`threat-detect-linux-amd64` / `threat-detect-linux-arm64`, downloaded via `gh release download` from [`github/gh-aw-threat-detection` releases](https://github.com/github/gh-aw-threat-detection/releases)) installed on the runner and executed under the AWF firewall (see [AWF section below](#agentic-workflow-firewall-awf)).
+2. **As a published release-asset binary** (Linux or macOS, amd64 or arm64, downloaded via `gh release download` from [`github/gh-aw-threat-detection` releases](https://github.com/github/gh-aw-threat-detection/releases)) installed on the runner and executed under the AWF firewall (see [AWF section below](#agentic-workflow-firewall-awf)).
 
 It detects three categories: **prompt injection**, **secret leak**, and **malicious patch**, and emits a strict JSON contract.
 
@@ -17,7 +17,7 @@ It detects three categories: **prompt injection**, **secret leak**, and **malici
 
 - **Language**: Go 1.26+ (module `github.com/github/gh-aw-threat-detection`)
 - **Binary**: `bin/threat-detect` (built via `make build`)
-- **Distribution**: published as GitHub Release assets (`threat-detect-linux-amd64`, `threat-detect-linux-arm64` + `checksums.txt`); no container image
+- **Distribution**: published as GitHub Release assets for Linux and macOS on amd64 and arm64, plus `checksums.txt`; no container image
 - **Spec**: [`specs/threat-detection-spec.md`](specs/threat-detection-spec.md) — W3C-style normative spec; the source of truth for behavior. [`specs/usage-spec.md`](specs/usage-spec.md) — W3C-style usage/integration spec (acquire, invoke, conclude).
 - **Engines supported**: `copilot` (default), `claude`, `codex` — invoked from `PATH`, not bundled into the binary
 - **Detection**: a single agentic CLI engine pass; the engine reports its verdict in-session via the `threat_detection_result` tool (out-of-band result sink), which is the sole source of the verdict
@@ -127,8 +127,12 @@ The detector reads the verdict exclusively from the out-of-band result sink. The
 Three workflows orchestrate releases:
 
 1. `.github/workflows/create-release-tag.yml` — manual; pushes `vX.Y.Z`.
-2. `.github/workflows/release.yml` — triggered by tag push; gated by `release-publish` environment; builds + publishes the `threat-detect-linux-amd64` and `threat-detect-linux-arm64` binaries as GitHub Release assets in a **prerelease**, recording each asset sha256 in the release notes.
+2. `.github/workflows/release.yml` — triggered by tag push; gated by `release-publish` environment; builds + publishes Linux and macOS binaries for amd64 and arm64 as GitHub Release assets in a **prerelease**, recording each asset sha256 in the release notes.
 3. `.github/workflows/promote-release.yml` — manual; gated by `release-promote`; re-downloads the asset, verifies its sha256 against the recorded value, and marks the GitHub release **Latest** (stable).
+
+`release-targets.txt` is the canonical platform/asset matrix consumed by both
+tagged and rolling release workflows. The Release Platform Parity workflow
+checks it against the supported asset names in `gh-aw`'s installer.
 
 The `latest` (non-prerelease) GitHub release and "Latest" badge **only move on explicit promotion** — never automatically.
 

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -187,10 +187,11 @@ Releases follow a **prerelease → promote** model:
    bump. The workflow validates `main` and pushes the next `vX.Y.Z` tag.
 
 2. **Build & Publish (automated)** — pushing a tag matching `v*` triggers the
-   [release workflow](.github/workflows/release.yml). It builds the
-   `threat-detect-linux-amd64` and `threat-detect-linux-arm64` binaries,
-   attaches them (plus a shared `checksums.txt`) to a **prerelease** on GitHub,
-   and records each asset's sha256 in the release notes.
+   [release workflow](.github/workflows/release.yml). It builds every platform
+   in [`release-targets.txt`](release-targets.txt) (Linux and macOS on amd64 and
+   arm64), attaches the binaries plus a shared `checksums.txt` to a
+   **prerelease** on GitHub, and records each asset's sha256 in the release
+   notes.
    The `release-publish` environment gate
    pauses the workflow before publishing so maintainers can abort if needed.
 
@@ -212,9 +213,9 @@ In addition to release tags, every push to `main` triggers the
 [publish-main workflow](.github/workflows/publish-main.yml), which builds the
 binary and republishes a single rolling `main` pre-release:
 
-- The `main` pre-release always carries the `threat-detect-linux-amd64` and
-  `threat-detect-linux-arm64` assets built from the most recent successful build
-  from `main`, versioned `main-<shortsha>`.
+- The `main` pre-release always carries every asset declared in
+  [`release-targets.txt`](release-targets.txt), built from the most recent
+  successful build from `main` and versioned `main-<shortsha>`.
 
 These are **unverified branch builds**. The `main` pre-release is not eligible
 for promotion. The **Latest** stable release pointer is
@@ -241,7 +242,10 @@ After the tag is pushed:
 
 1. Approve the `release-publish` environment gate when the workflow pauses.
 2. Verify the prerelease on the [Releases page](../../releases) and test the
-   version-tagged `threat-detect-linux-amd64` / `threat-detect-linux-arm64` assets.
+   version-tagged binaries for every platform in
+   [`release-targets.txt`](release-targets.txt). Confirm `checksums.txt` contains
+   and verifies each asset; test binaries on their matching Linux and macOS
+   architectures before promotion.
 3. When satisfied, go to **Actions → Promote Release**, enter the tag, and run
    the workflow. Approve the `release-promote` environment gate.
 4. Confirm the **Latest** release now resolves to the new version.

--- a/README.md
+++ b/README.md
@@ -178,20 +178,23 @@ log artifact) together with `gh-aw`'s `logs` tooling.
 
 ### Released binary
 
-The `threat-detect` binary is published as GitHub Release assets
-(`threat-detect-linux-amd64` and `threat-detect-linux-arm64`) alongside a
-shared `checksums.txt`. Download the asset matching your runner architecture and
-run it directly:
+The `threat-detect` binary is published as GitHub Release assets for Linux and
+macOS on amd64 and arm64 alongside a shared `checksums.txt`. Download the asset
+matching your runner platform and run it directly:
 
 ```bash
-# Pick the asset for your architecture (amd64 or arm64).
-case "$(uname -m)" in
-  x86_64|amd64) asset=threat-detect-linux-amd64 ;;
-  aarch64|arm64) asset=threat-detect-linux-arm64 ;;
+# Pick the asset for your operating system and architecture.
+case "$(uname -s)/$(uname -m)" in
+  Linux/x86_64|Linux/amd64)  asset=threat-detect-linux-amd64 ;;
+  Linux/aarch64|Linux/arm64) asset=threat-detect-linux-arm64 ;;
+  Darwin/x86_64)             asset=threat-detect-darwin-x64 ;;
+  Darwin/arm64)              asset=threat-detect-darwin-arm64 ;;
+  *) echo "unsupported platform" >&2; exit 1 ;;
 esac
 gh release download --repo github/gh-aw-threat-detection \
   --pattern "$asset" --pattern checksums.txt
-sha256sum --check --ignore-missing checksums.txt
+awk -v asset="$asset" '$2 == asset' checksums.txt |
+  if command -v sha256sum >/dev/null; then sha256sum --check; else shasum -a 256 --check; fi
 install -m 0755 "$asset" ./threat-detect
 ./threat-detect /path/to/artifacts
 ```
@@ -199,6 +202,11 @@ install -m 0755 "$asset" ./threat-detect
 Omitting a tag downloads the latest stable (promoted) release. Production
 AI-backed detection requires the selected engine CLI and its authentication to
 be available on the runner where the binary runs.
+
+The macOS binaries are not code-signed or notarized. The `gh-aw` installer
+checksum-verifies CI downloads before execution. Browser downloads may be
+quarantined by Gatekeeper; prefer the installer, or verify the checksum before
+removing quarantine.
 
 ### Input (Artifacts Directory)
 
@@ -268,10 +276,12 @@ Decisions for the unresolved extraction questions:
 ## Release Asset Setup
 
 The repository can remain private while publishing release assets. The release
-workflow builds `threat-detect-linux-amd64` and `threat-detect-linux-arm64`,
-records each asset's sha256 in the release notes, and attaches them (plus a
-shared `checksums.txt`) to a GitHub **prerelease** using the automatic
-`GITHUB_TOKEN` with `contents: write`.
+workflow builds Linux and macOS binaries for amd64 and arm64, records each
+asset's sha256 in the release notes, and attaches them (plus a shared
+`checksums.txt`) to a GitHub **prerelease** using the automatic `GITHUB_TOKEN`
+with `contents: write`. `release-targets.txt` is the canonical build matrix for
+both tagged and rolling releases. The scheduled Release Platform Parity workflow
+compares its asset names with the platforms supported by `gh-aw`'s installer.
 
 Maintainers need to configure the following before the binary is consumed by `gh-aw`:
 
@@ -305,7 +315,7 @@ This repository includes three Agentic Workflows smoke tests, one per engine:
 - `.github/workflows/smoke-claude-standalone.md`
 - `.github/workflows/smoke-codex-standalone.md`
 
-Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can be dispatched manually with a `scope` input — `standard` (the three pinned `*-standalone` smokes), `standard+latest` (also their `*-standalone-latest` counterparts), or `latest` (only the latest smokes). The matching `.lock.yml` files are the compiled AW workflows. The `*-standalone` variants set `features: gh-aw-detection: true`, so gh-aw natively downloads this repo's released `threat-detect-linux-amd64` binary (pinned to a promoted release tag), runs it under AWF, and reads the structured `detection_result.json` via `threat-detect conclude`. Each also has a `smoke-<engine>-standalone-latest.md` counterpart that tests the newest detector build — see [Testing the Latest Detector Under AWF](#testing-the-latest-detector-under-awf).
+Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can be dispatched manually with a `scope` input — `standard` (the three pinned `*-standalone` smokes), `standard+latest` (also their `*-standalone-latest` counterparts), or `latest` (only the latest smokes). The matching `.lock.yml` files are the compiled AW workflows. The `*-standalone` variants set `features: gh-aw-detection: true`, so gh-aw natively downloads this repo's released binary matching the runner platform (pinned to a promoted release tag), runs it under AWF, and reads the structured `detection_result.json` via `threat-detect conclude`. Each also has a `smoke-<engine>-standalone-latest.md` counterpart that tests the newest detector build — see [Testing the Latest Detector Under AWF](#testing-the-latest-detector-under-awf).
 
 ### Detection-only Workflow
 
@@ -407,7 +417,9 @@ const DefaultThreatDetectionRepo    = "github/gh-aw-threat-detection"
 const DefaultThreatDetectionVersion = "v0.0.2"
 ```
 
-The detection job in compiled workflows downloads the pinned `threat-detect` release asset matching the runner architecture (`threat-detect-linux-amd64` or `threat-detect-linux-arm64`) and runs it instead of inline AI engine invocation.
+The detection job in compiled workflows downloads the pinned `threat-detect`
+release asset matching the runner operating system and architecture and runs it
+instead of inline AI engine invocation.
 
 ## Specification
 

--- a/release-targets.txt
+++ b/release-targets.txt
@@ -1,0 +1,5 @@
+# goos goarch release-asset
+linux amd64 threat-detect-linux-amd64
+linux arm64 threat-detect-linux-arm64
+darwin amd64 threat-detect-darwin-x64
+darwin arm64 threat-detect-darwin-arm64

--- a/scripts/check-release-platforms.sh
+++ b/scripts/check-release-platforms.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+targets_file="${RELEASE_TARGETS_FILE:-${repo_root}/release-targets.txt}"
+installer_file="${1:-}"
+temp_dir=""
+
+if [ -z "$installer_file" ]; then
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' EXIT
+  installer_file="${temp_dir}/install_threat_detect_binary.sh"
+  curl -fsSL --retry 3 --retry-all-errors \
+    "https://raw.githubusercontent.com/github/gh-aw/main/actions/setup/sh/install_threat_detect_binary.sh" \
+    -o "$installer_file"
+fi
+
+manifest_targets="$(
+  awk '
+    /^[[:space:]]*(#|$)/ { next }
+    NF != 3 {
+      printf "invalid release target at line %d: expected <goos> <goarch> <asset>\n", NR > "/dev/stderr"
+      exit 1
+    }
+    {
+      platform = $1 "/" $2
+      if (platforms[platform]++) {
+        printf "duplicate release platform at line %d: %s\n", NR, platform > "/dev/stderr"
+        exit 1
+      }
+      if (assets[$3]++) {
+        printf "duplicate release asset at line %d: %s\n", NR, $3 > "/dev/stderr"
+        exit 1
+      }
+      print $1, $2, $3
+    }
+  ' "$targets_file" | sort
+)"
+
+installer_targets="$(
+  awk '
+    function canonical_arch(pattern) {
+      if (pattern ~ /x86_64|amd64/) {
+        return "amd64"
+      }
+      if (pattern ~ /aarch64|arm64/) {
+        return "arm64"
+      }
+      return ""
+    }
+
+    /^install_linux_binary\(\)/ {
+      function_os = "linux"
+      next
+    }
+    /^install_darwin_binary\(\)/ {
+      function_os = "darwin"
+      next
+    }
+    function_os != "" && /^}/ {
+      function_os = ""
+      next
+    }
+    function_os != "" && /binary_name="threat-detect-[^"]+"/ {
+      arch_pattern = $0
+      sub(/\).*/, "", arch_pattern)
+      sub(/^[[:space:]]*/, "", arch_pattern)
+      arch = canonical_arch(arch_pattern)
+      if (arch == "") {
+        printf "unsupported installer architecture mapping: %s\n", $0 > "/dev/stderr"
+        exit 1
+      }
+
+      asset = $0
+      sub(/.*binary_name="/, "", asset)
+      sub(/".*/, "", asset)
+      print function_os, arch, asset
+    }
+
+    /^case "\$OS" in/ {
+      in_os_dispatch = 1
+      next
+    }
+    in_os_dispatch && /^[[:space:]]*Linux\)/ {
+      dispatch_os = "linux"
+      next
+    }
+    in_os_dispatch && /^[[:space:]]*Darwin\)/ {
+      dispatch_os = "darwin"
+      next
+    }
+    in_os_dispatch && dispatch_os == "linux" && /^[[:space:]]*install_linux_binary/ {
+      reachable["linux"] = 1
+      dispatch_os = ""
+      next
+    }
+    in_os_dispatch && dispatch_os == "darwin" && /^[[:space:]]*install_darwin_binary/ {
+      reachable["darwin"] = 1
+      dispatch_os = ""
+      next
+    }
+
+    END {
+      if (!reachable["linux"] || !reachable["darwin"]) {
+        print "installer does not dispatch both Linux and Darwin install functions" > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' "$installer_file" | sort -u
+)"
+
+if [ -z "$manifest_targets" ]; then
+  echo "ERROR: no release targets found in ${targets_file}" >&2
+  exit 1
+fi
+if [ -z "$installer_targets" ]; then
+  echo "ERROR: no supported platform mappings found in ${installer_file}" >&2
+  exit 1
+fi
+
+if ! diff -u \
+  <(printf '%s\n' "$installer_targets") \
+  <(printf '%s\n' "$manifest_targets"); then
+  echo "ERROR: gh-aw installer platform mappings and release targets differ" >&2
+  exit 1
+fi
+
+echo "Release targets match gh-aw installer platform mappings:"
+while IFS= read -r target; do
+  printf '  %s\n' "$target"
+done <<< "$manifest_targets"

--- a/specs/usage-spec.md
+++ b/specs/usage-spec.md
@@ -54,8 +54,10 @@ here as `TD-XX`.
 Release asset from `github/gh-aw-threat-detection`. The host MUST NOT build the
 detector from source as part of a production detection job.
 
-**U-02**: The host MUST select the release asset matching the runner
-architecture: `threat-detect-linux-amd64` or `threat-detect-linux-arm64`.
+**U-02**: The host MUST select the release asset matching the runner operating
+system and architecture: `threat-detect-linux-amd64`,
+`threat-detect-linux-arm64`, `threat-detect-darwin-x64`, or
+`threat-detect-darwin-arm64`.
 
 **U-03**: The host MUST verify the downloaded asset against the `sha256` value
 recorded for that asset (via `checksums.txt` published alongside the assets, or
@@ -73,15 +75,25 @@ repository is approved (per TD-27).
 Example acquisition (informative):
 
 ```bash
-case "$(uname -m)" in
-  x86_64|amd64) asset=threat-detect-linux-amd64 ;;
-  aarch64|arm64) asset=threat-detect-linux-arm64 ;;
+case "$(uname -s)/$(uname -m)" in
+  Linux/x86_64|Linux/amd64)  asset=threat-detect-linux-amd64 ;;
+  Linux/aarch64|Linux/arm64) asset=threat-detect-linux-arm64 ;;
+  Darwin/x86_64)             asset=threat-detect-darwin-x64 ;;
+  Darwin/arm64)              asset=threat-detect-darwin-arm64 ;;
+  *) echo "unsupported platform" >&2; exit 1 ;;
 esac
 gh release download v0.0.2 --repo github/gh-aw-threat-detection \
   --pattern "$asset" --pattern checksums.txt
-sha256sum --check --ignore-missing checksums.txt
+awk -v asset="$asset" '$2 == asset' checksums.txt |
+  if command -v sha256sum >/dev/null; then sha256sum --check; else shasum -a 256 --check; fi
 install -m 0755 "$asset" ./threat-detect
 ```
+
+The macOS assets are not code-signed or notarized. Downloads performed by the
+`gh-aw` installer are intended for CI runners and are checksum-verified before
+execution. A browser download may receive a quarantine attribute and be blocked
+by Gatekeeper; users should prefer the installer, or verify the checksum before
+removing quarantine.
 
 ---
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ72AV8GHYCYH3QNCNX2DT1H)

## Summary
- publish `darwin/amd64` and `darwin/arm64` binaries from the same canonical target manifest as Linux assets
- include every platform binary in tagged and rolling release checksums, notes, and uploads
- add a scheduled/PR parity check against `gh-aw` installer platform mappings
- document macOS acquisition and unsigned/notarized Gatekeeper implications

Closes #702