### PR TITLE
feat(cli): add explicit workflow-context flags and prompt diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ threat-detect [flags] <artifacts-dir>
 - `--engine` — AI engine to use (`copilot`, `claude`, `codex`). Default: `copilot`
 - `--model` — Model override for the engine. When unset, the detector resolves the model from `GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}`, then the engine CLI's native model env var (`COPILOT_MODEL`, `ANTHROPIC_MODEL`)
 - `--prompt-template` — Path to custom prompt template
+- `--workflow-name` — Workflow name for the prompt. Overrides `WORKFLOW_NAME`
+- `--workflow-description` — Workflow description for the prompt. Overrides `WORKFLOW_DESCRIPTION`
+- `--custom-prompt` — Additional detection instructions appended to the prompt. Overrides `CUSTOM_PROMPT`
+- `--custom-prompt-file` — Path to a file with additional detection instructions. Takes precedence over `--custom-prompt` and `CUSTOM_PROMPT`
 - `--output` — Path to write JSON result (defaults to stdout)
 - `--log-file` — Path to write structured JSONL run logs (one JSON object per line). Env: `THREAT_DETECTION_LOG_FILE`
 - `--retries` — Retries for malformed detection outputs. Default: `1` (env: `THREAT_DETECTION_RETRIES`)
@@ -287,9 +291,9 @@ No additional secrets are required for unit tests, `make build`, `make test`, or
 | `COPILOT_GITHUB_TOKEN` | Running `--engine copilot` in an environment that needs explicit token-based Copilot authentication | Use a fine-grained PAT owned by a user account with **Account permissions → Copilot Requests: Read**. `GITHUB_TOKEN` is not sufficient for Copilot inference. |
 | `ANTHROPIC_API_KEY` | Running `--engine claude` with the Claude CLI | Not used by unit tests. |
 | `OPENAI_API_KEY` | Running `--engine codex` with the Codex CLI | Not used by unit tests. |
-| `WORKFLOW_NAME` | Optional local runs | Included in the generated prompt. |
-| `WORKFLOW_DESCRIPTION` | Optional local runs | Included in the generated prompt. |
-| `CUSTOM_PROMPT` | Optional local runs | Appended to the default detection prompt. |
+| `WORKFLOW_NAME` | Optional local runs | Included in the generated prompt. Overridable with `--workflow-name`. |
+| `WORKFLOW_DESCRIPTION` | Optional local runs | Included in the generated prompt. Overridable with `--workflow-description`. |
+| `CUSTOM_PROMPT` | Optional local runs | Appended to the default detection prompt. Overridable with `--custom-prompt` / `--custom-prompt-file`. |
 
 ## Development
 

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -201,29 +201,39 @@ func run() (code int) {
 	}
 	logger.Info("artifacts_loaded", map[string]any{"artifacts_dir": artifactsDir})
 
-	// Resolve workflow-context overrides. Explicit flags win over the environment
-	// variables consumed by artifacts.Load; empty flags leave the loaded value
-	// (env or built-in default) untouched. This gives gh-aw and local callers a
-	// plumbing-independent way to inject workflow context so it cannot be silently
-	// dropped by an env-passthrough filter.
-	if workflowName != "" {
+	// Resolve workflow-context overrides. Provenance is tracked from whether a
+	// flag was explicitly provided (FlagSet.Visit) rather than from the value's
+	// content, so an explicit flag wins even when empty and a value that merely
+	// equals the built-in default text is not misreported as defaulted. This
+	// gives gh-aw and local callers a plumbing-independent way to inject workflow
+	// context so it cannot be silently dropped by an env-passthrough filter.
+	providedFlags := map[string]bool{}
+	flag.CommandLine.Visit(func(f *flag.Flag) { providedFlags[f.Name] = true })
+
+	// A value is "defaulted" only when neither the flag nor its environment
+	// variable supplied it; equality with the fallback text is not sufficient.
+	nameDefaulted := !providedFlags["workflow-name"] && os.Getenv("WORKFLOW_NAME") == ""
+	descriptionDefaulted := !providedFlags["workflow-description"] && os.Getenv("WORKFLOW_DESCRIPTION") == ""
+	if providedFlags["workflow-name"] {
 		arts.WorkflowName = workflowName
 	}
-	if workflowDescription != "" {
+	if providedFlags["workflow-description"] {
 		arts.WorkflowDescription = workflowDescription
 	}
 
 	// Custom prompt precedence: --custom-prompt-file, then --custom-prompt, then
-	// the CUSTOM_PROMPT environment variable already loaded into arts.
+	// the CUSTOM_PROMPT environment variable already loaded into arts. Presence is
+	// determined by explicit flag provision, so an explicit empty flag clears an
+	// env-supplied prompt (flags win).
 	customPromptSource := "none"
 	if arts.CustomPrompt != "" {
 		customPromptSource = "env"
 	}
-	if customPrompt != "" {
+	if providedFlags["custom-prompt"] {
 		arts.CustomPrompt = customPrompt
 		customPromptSource = "flag"
 	}
-	if customPromptFile != "" {
+	if providedFlags["custom-prompt-file"] {
 		data, err := os.ReadFile(customPromptFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error reading custom prompt file: %v\n", err)
@@ -235,15 +245,13 @@ func run() (code int) {
 		customPromptSource = "file"
 	}
 
-	nameDefaulted := arts.WorkflowName == artifacts.DefaultWorkflowName
-	descriptionDefaulted := arts.WorkflowDescription == artifacts.DefaultWorkflowDescription
-
 	// Surface the resolved workflow context on stderr so a dropped CUSTOM_PROMPT
 	// or missing workflow name/description is diagnosable from the run log alone,
 	// not silently absorbed into the prompt.
 	fmt.Fprintf(os.Stderr,
-		"Prompt context: workflow_name=%q (defaulted=%t) workflow_description_defaulted=%t custom_prompt_source=%s custom_prompt_bytes=%d\n",
-		arts.WorkflowName, nameDefaulted, descriptionDefaulted, customPromptSource, len(arts.CustomPrompt))
+		"Prompt context: workflow_name=%q (defaulted=%t) workflow_description=%q (defaulted=%t) custom_prompt_applied=%t custom_prompt_source=%s custom_prompt_bytes=%d\n",
+		arts.WorkflowName, nameDefaulted, arts.WorkflowDescription, descriptionDefaulted,
+		arts.CustomPrompt != "", customPromptSource, len(arts.CustomPrompt))
 
 	// Build the prompt
 	promptTemplate := ""

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -99,13 +99,17 @@ func run() (code int) {
 	}()
 
 	var (
-		engineID   string
-		model      string
-		promptFile string
-		outputJSON string
-		logFile    string
-		version    bool
-		retries    int
+		engineID            string
+		model               string
+		promptFile          string
+		outputJSON          string
+		logFile             string
+		workflowName        string
+		workflowDescription string
+		customPrompt        string
+		customPromptFile    string
+		version             bool
+		retries             int
 	)
 
 	// Parse flags with ContinueOnError so usage/flag errors return through the
@@ -118,6 +122,10 @@ func run() (code int) {
 	flag.StringVar(&promptFile, "prompt-template", "", "Path to custom prompt template (defaults to built-in)")
 	flag.StringVar(&outputJSON, "output", "", "Path to write JSON result (defaults to stdout)")
 	flag.StringVar(&logFile, "log-file", os.Getenv("THREAT_DETECTION_LOG_FILE"), "Path to write JSONL run logs (env: THREAT_DETECTION_LOG_FILE)")
+	flag.StringVar(&workflowName, "workflow-name", "", "Workflow name for the prompt (overrides WORKFLOW_NAME)")
+	flag.StringVar(&workflowDescription, "workflow-description", "", "Workflow description for the prompt (overrides WORKFLOW_DESCRIPTION)")
+	flag.StringVar(&customPrompt, "custom-prompt", "", "Additional detection instructions appended to the prompt (overrides CUSTOM_PROMPT)")
+	flag.StringVar(&customPromptFile, "custom-prompt-file", "", "Path to a file with additional detection instructions (takes precedence over --custom-prompt and CUSTOM_PROMPT)")
 	flag.BoolVar(&version, "version", false, "Print version and exit")
 	flag.IntVar(&retries, "retries", envInt("THREAT_DETECTION_RETRIES", 1), "Retries for malformed detection outputs (env: THREAT_DETECTION_RETRIES)")
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
@@ -193,6 +201,50 @@ func run() (code int) {
 	}
 	logger.Info("artifacts_loaded", map[string]any{"artifacts_dir": artifactsDir})
 
+	// Resolve workflow-context overrides. Explicit flags win over the environment
+	// variables consumed by artifacts.Load; empty flags leave the loaded value
+	// (env or built-in default) untouched. This gives gh-aw and local callers a
+	// plumbing-independent way to inject workflow context so it cannot be silently
+	// dropped by an env-passthrough filter.
+	if workflowName != "" {
+		arts.WorkflowName = workflowName
+	}
+	if workflowDescription != "" {
+		arts.WorkflowDescription = workflowDescription
+	}
+
+	// Custom prompt precedence: --custom-prompt-file, then --custom-prompt, then
+	// the CUSTOM_PROMPT environment variable already loaded into arts.
+	customPromptSource := "none"
+	if arts.CustomPrompt != "" {
+		customPromptSource = "env"
+	}
+	if customPrompt != "" {
+		arts.CustomPrompt = customPrompt
+		customPromptSource = "flag"
+	}
+	if customPromptFile != "" {
+		data, err := os.ReadFile(customPromptFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading custom prompt file: %v\n", err)
+			logger.Error("custom_prompt_read_failed", map[string]any{"path": customPromptFile, "error": err.Error()})
+			reason = reasonConfigError
+			return exitError
+		}
+		arts.CustomPrompt = string(data)
+		customPromptSource = "file"
+	}
+
+	nameDefaulted := arts.WorkflowName == artifacts.DefaultWorkflowName
+	descriptionDefaulted := arts.WorkflowDescription == artifacts.DefaultWorkflowDescription
+
+	// Surface the resolved workflow context on stderr so a dropped CUSTOM_PROMPT
+	// or missing workflow name/description is diagnosable from the run log alone,
+	// not silently absorbed into the prompt.
+	fmt.Fprintf(os.Stderr,
+		"Prompt context: workflow_name=%q (defaulted=%t) workflow_description_defaulted=%t custom_prompt_source=%s custom_prompt_bytes=%d\n",
+		arts.WorkflowName, nameDefaulted, descriptionDefaulted, customPromptSource, len(arts.CustomPrompt))
+
 	// Build the prompt
 	promptTemplate := ""
 	if promptFile != "" {
@@ -212,7 +264,16 @@ func run() (code int) {
 		reason = reasonConfigError
 		return exitError
 	}
-	logger.Info("prompt_built", map[string]any{"prompt_bytes": len(prompt)})
+	logger.Info("prompt_built", map[string]any{
+		"prompt_bytes":                   len(prompt),
+		"workflow_name":                  arts.WorkflowName,
+		"workflow_description":           arts.WorkflowDescription,
+		"workflow_name_defaulted":        nameDefaulted,
+		"workflow_description_defaulted": descriptionDefaulted,
+		"custom_prompt_applied":          arts.CustomPrompt != "",
+		"custom_prompt_source":           customPromptSource,
+		"custom_prompt_bytes":            len(arts.CustomPrompt),
+	})
 
 	// Create engine
 	eng, err := engine.New(engineID, model)

--- a/cmd/threat-detect/promptcontext_test.go
+++ b/cmd/threat-detect/promptcontext_test.go
@@ -20,6 +20,11 @@ func runDetectionForPromptContext(t *testing.T, env map[string]string, extraArgs
 
 	fullEnv := map[string]string{
 		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		// Clear inherited workflow-context vars so the suite is deterministic
+		// regardless of the developer's shell; cases overlay explicit values.
+		"WORKFLOW_NAME":        "",
+		"WORKFLOW_DESCRIPTION": "",
+		"CUSTOM_PROMPT":        "",
 	}
 	for k, v := range env {
 		fullEnv[k] = v
@@ -120,6 +125,42 @@ func TestPromptContextCustomPromptFileWins(t *testing.T) {
 	}
 	if bytes, ok := built["custom_prompt_bytes"].(float64); !ok || int(bytes) != len("from file") {
 		t.Errorf("custom_prompt_bytes = %v, want %d", built["custom_prompt_bytes"], len("from file"))
+	}
+}
+
+func TestPromptContextExplicitDefaultTextIsNotDefaulted(t *testing.T) {
+	// Supplying the fallback text explicitly must not be misreported as defaulted.
+	built, stderr := runDetectionForPromptContext(t, nil,
+		"-workflow-name", "Unnamed Workflow",
+		"-workflow-description", "No description provided",
+	)
+
+	if built["workflow_name_defaulted"] != false {
+		t.Errorf("workflow_name_defaulted = %v, want false", built["workflow_name_defaulted"])
+	}
+	if built["workflow_description_defaulted"] != false {
+		t.Errorf("workflow_description_defaulted = %v, want false", built["workflow_description_defaulted"])
+	}
+	if !strings.Contains(stderr, "workflow_description=\"No description provided\"") {
+		t.Errorf("stderr missing resolved description, got:\n%s", stderr)
+	}
+}
+
+func TestPromptContextEmptyFlagClearsEnvCustomPrompt(t *testing.T) {
+	// An explicit empty --custom-prompt must win over CUSTOM_PROMPT (flags win),
+	// clearing the applied prompt while recording the flag as its provenance.
+	built, _ := runDetectionForPromptContext(t, map[string]string{
+		"CUSTOM_PROMPT": "from env",
+	}, "-custom-prompt", "")
+
+	if built["custom_prompt_applied"] != false {
+		t.Errorf("custom_prompt_applied = %v, want false", built["custom_prompt_applied"])
+	}
+	if built["custom_prompt_source"] != "flag" {
+		t.Errorf("custom_prompt_source = %v, want flag", built["custom_prompt_source"])
+	}
+	if bytes, ok := built["custom_prompt_bytes"].(float64); !ok || int(bytes) != 0 {
+		t.Errorf("custom_prompt_bytes = %v, want 0", built["custom_prompt_bytes"])
 	}
 }
 

--- a/cmd/threat-detect/promptcontext_test.go
+++ b/cmd/threat-detect/promptcontext_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runDetectionForPromptContext runs a full detection pass against a fake copilot
+// that records a safe verdict, returning the parsed prompt_built log record and
+// the captured stderr. Extra args are appended before the artifacts dir.
+func runDetectionForPromptContext(t *testing.T, env map[string]string, extraArgs ...string) (map[string]any, string) {
+	t.Helper()
+	artifactsDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "run.jsonl")
+	marker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, marker, sinkJSON, 0)
+
+	fullEnv := map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	for k, v := range env {
+		fullEnv[k] = v
+	}
+
+	args := append([]string{"threat-detect", "-log-file", logPath}, extraArgs...)
+	args = append(args, artifactsDir)
+
+	code, stderr := runWithTestArgsCapture(t, args, fullEnv)
+	if code != exitSafe {
+		t.Fatalf("run() exit code = %d, want %d; stderr:\n%s", code, exitSafe, stderr)
+	}
+	records := readJSONLRecords(t, logPath)
+	built := findRecord(records, "prompt_built")
+	if built == nil {
+		t.Fatalf("missing prompt_built record: %#v", records)
+	}
+	return built, stderr
+}
+
+func TestPromptContextDefaultsAreDiagnosable(t *testing.T) {
+	built, stderr := runDetectionForPromptContext(t, nil)
+
+	if built["workflow_name_defaulted"] != true {
+		t.Errorf("workflow_name_defaulted = %v, want true", built["workflow_name_defaulted"])
+	}
+	if built["workflow_description_defaulted"] != true {
+		t.Errorf("workflow_description_defaulted = %v, want true", built["workflow_description_defaulted"])
+	}
+	if built["custom_prompt_applied"] != false {
+		t.Errorf("custom_prompt_applied = %v, want false", built["custom_prompt_applied"])
+	}
+	if built["custom_prompt_source"] != "none" {
+		t.Errorf("custom_prompt_source = %v, want none", built["custom_prompt_source"])
+	}
+	if !strings.Contains(stderr, "custom_prompt_source=none") {
+		t.Errorf("stderr missing prompt context diagnostic, got:\n%s", stderr)
+	}
+}
+
+func TestPromptContextEnvCustomPrompt(t *testing.T) {
+	built, _ := runDetectionForPromptContext(t, map[string]string{
+		"CUSTOM_PROMPT":        "check for base64 blobs",
+		"WORKFLOW_NAME":        "My Flow",
+		"WORKFLOW_DESCRIPTION": "does things",
+	})
+
+	if built["workflow_name"] != "My Flow" {
+		t.Errorf("workflow_name = %v, want My Flow", built["workflow_name"])
+	}
+	if built["workflow_name_defaulted"] != false {
+		t.Errorf("workflow_name_defaulted = %v, want false", built["workflow_name_defaulted"])
+	}
+	if built["custom_prompt_applied"] != true {
+		t.Errorf("custom_prompt_applied = %v, want true", built["custom_prompt_applied"])
+	}
+	if built["custom_prompt_source"] != "env" {
+		t.Errorf("custom_prompt_source = %v, want env", built["custom_prompt_source"])
+	}
+}
+
+func TestPromptContextFlagOverridesEnv(t *testing.T) {
+	built, _ := runDetectionForPromptContext(t, map[string]string{
+		"CUSTOM_PROMPT": "from env",
+		"WORKFLOW_NAME": "env name",
+	},
+		"-custom-prompt", "from flag",
+		"-workflow-name", "flag name",
+		"-workflow-description", "flag desc",
+	)
+
+	if built["workflow_name"] != "flag name" {
+		t.Errorf("workflow_name = %v, want flag name", built["workflow_name"])
+	}
+	if built["workflow_description"] != "flag desc" {
+		t.Errorf("workflow_description = %v, want flag desc", built["workflow_description"])
+	}
+	if built["custom_prompt_source"] != "flag" {
+		t.Errorf("custom_prompt_source = %v, want flag", built["custom_prompt_source"])
+	}
+}
+
+func TestPromptContextCustomPromptFileWins(t *testing.T) {
+	promptFile := filepath.Join(t.TempDir(), "extra.md")
+	if err := os.WriteFile(promptFile, []byte("from file"), 0o644); err != nil {
+		t.Fatalf("writing custom prompt file: %v", err)
+	}
+
+	built, _ := runDetectionForPromptContext(t, map[string]string{
+		"CUSTOM_PROMPT": "from env",
+	},
+		"-custom-prompt", "from flag",
+		"-custom-prompt-file", promptFile,
+	)
+
+	if built["custom_prompt_source"] != "file" {
+		t.Errorf("custom_prompt_source = %v, want file", built["custom_prompt_source"])
+	}
+	if bytes, ok := built["custom_prompt_bytes"].(float64); !ok || int(bytes) != len("from file") {
+		t.Errorf("custom_prompt_bytes = %v, want %d", built["custom_prompt_bytes"], len("from file"))
+	}
+}
+
+func TestPromptContextRejectsUnreadableCustomPromptFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.md")
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-custom-prompt-file", missing,
+		t.TempDir(),
+	}, nil)
+
+	if code != exitError {
+		t.Fatalf("run() exit code = %d, want %d", code, exitError)
+	}
+	if !strings.Contains(stderr, "Error reading custom prompt file") {
+		t.Fatalf("stderr missing custom prompt read error, got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "reason=config_error") {
+		t.Fatalf("stderr missing config_error status, got:\n%s", stderr)
+	}
+}

--- a/pkg/artifacts/artifacts.go
+++ b/pkg/artifacts/artifacts.go
@@ -9,6 +9,15 @@ import (
 	"strings"
 )
 
+// Default workflow-context values used when neither the corresponding flag nor
+// environment variable supplies one. They are exported so callers (e.g. the CLI)
+// can detect when a value was defaulted rather than provided, which is useful
+// for diagnosing dropped workflow-context plumbing.
+const (
+	DefaultWorkflowName        = "Unnamed Workflow"
+	DefaultWorkflowDescription = "No description provided"
+)
+
 // Artifacts holds the loaded artifact information for threat detection.
 type Artifacts struct {
 	// Dir is the base artifacts directory path.
@@ -56,8 +65,8 @@ func Load(dir string) (*Artifacts, error) {
 
 	arts := &Artifacts{
 		Dir:                 dir,
-		WorkflowName:        envOrDefault("WORKFLOW_NAME", "Unnamed Workflow"),
-		WorkflowDescription: envOrDefault("WORKFLOW_DESCRIPTION", "No description provided"),
+		WorkflowName:        envOrDefault("WORKFLOW_NAME", DefaultWorkflowName),
+		WorkflowDescription: envOrDefault("WORKFLOW_DESCRIPTION", DefaultWorkflowDescription),
 		CustomPrompt:        os.Getenv("CUSTOM_PROMPT"),
 	}
 

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -230,8 +230,12 @@ flags so it cannot be silently dropped by environment-variable plumbing:
 `--workflow-name` overrides `WORKFLOW_NAME`, `--workflow-description` overrides
 `WORKFLOW_DESCRIPTION`, and `--custom-prompt` (or `--custom-prompt-file`, which
 reads the instructions from a file) overrides `CUSTOM_PROMPT`. When both a flag
-and its environment variable are set, the flag wins; `--custom-prompt-file` takes
-precedence over `--custom-prompt`. The detector MUST record the resolved workflow
+and its environment variable are set, the flag wins (even when empty, so an
+explicit empty `--custom-prompt` clears an env-supplied prompt);
+`--custom-prompt-file` takes precedence over `--custom-prompt`. A value is
+reported as defaulted only when neither its flag nor its environment variable was
+provided (not merely because it equals the fallback text). The detector MUST
+record the resolved workflow
 name and description, whether each fell back to its built-in default, and the
 source and byte length of any applied custom prompt (`flag`, `file`, `env`, or
 `none`) on the `prompt_built` run-log event and on a single stderr diagnostic

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -225,6 +225,18 @@ treats a missing verdict as a recoverable `parse_error` and proceeds.
 | `WORKFLOW_DESCRIPTION` | Description of the workflow |
 | `CUSTOM_PROMPT` | Additional detection instructions |
 
+**TD-22-flags**: The detector MUST also accept the workflow context via explicit
+flags so it cannot be silently dropped by environment-variable plumbing:
+`--workflow-name` overrides `WORKFLOW_NAME`, `--workflow-description` overrides
+`WORKFLOW_DESCRIPTION`, and `--custom-prompt` (or `--custom-prompt-file`, which
+reads the instructions from a file) overrides `CUSTOM_PROMPT`. When both a flag
+and its environment variable are set, the flag wins; `--custom-prompt-file` takes
+precedence over `--custom-prompt`. The detector MUST record the resolved workflow
+name and description, whether each fell back to its built-in default, and the
+source and byte length of any applied custom prompt (`flag`, `file`, `env`, or
+`none`) on the `prompt_built` run-log event and on a single stderr diagnostic
+line, so a dropped custom prompt or missing workflow context is diagnosable.
+
 **TD-22a**: When the model is not set explicitly (via the `--model` flag or engine configuration), the detector MUST resolve the model for the selected engine from environment variables, in the following precedence:
 
 1. the engine-specific detection model variable `GH_AW_MODEL_DETECTION_{COPILOT,CLAUDE,CODEX}`;


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ7120DWJ0VMQZ6CDNXBN3P0)

## Summary

Addresses the **this-repo** portion of #688: `CUSTOM_PROMPT` / `WORKFLOW_NAME` / `WORKFLOW_DESCRIPTION` could be silently dropped by env plumbing, so `safe-outputs.threat-detection.prompt` had no effect and the prompt reported the workflow as `Unnamed Workflow` with no signal.

This makes the workflow context **injectable independently of env vars** and **diagnosable** when absent.

## Changes

- **New CLI flags** (`cmd/threat-detect/main.go`):
  - `--workflow-name` — overrides `WORKFLOW_NAME`
  - `--workflow-description` — overrides `WORKFLOW_DESCRIPTION`
  - `--custom-prompt` — overrides `CUSTOM_PROMPT`
  - `--custom-prompt-file` — reads instructions from a file; takes precedence over `--custom-prompt` and `CUSTOM_PROMPT`
  - Precedence: `--custom-prompt-file` > `--custom-prompt` > `CUSTOM_PROMPT`. An unreadable custom-prompt file is a `config_error`.
- **Diagnostics**: the `prompt_built` run-log event now records `workflow_name`, `workflow_description`, `workflow_name_defaulted`, `workflow_description_defaulted`, `custom_prompt_applied`, `custom_prompt_source` (`flag`/`file`/`env`/`none`), and `custom_prompt_bytes`. A single stderr `Prompt context:` line mirrors this, so a dropped custom prompt or missing workflow context is visible from logs alone.
- **`pkg/artifacts`**: exported `DefaultWorkflowName` / `DefaultWorkflowDescription` so callers can detect a defaulted value.
- **Tests**: `promptcontext_test.go` covering defaults, env, flag-over-env, file precedence, and the unreadable-file error path.
- **Docs**: README CLI/env tables + spec `TD-22-flags`.

## Validation

`make fmt lint build test` and `go vet ./...` all pass. Verified the stderr diagnostic manually.

## Out of scope (cross-repo)

Item 1 (adding the three vars to the external detector execution step + AWF env passthrough) belongs in `github/gh-aw`; item 4's smoke workflow with `safe-outputs.threat-detection.prompt` depends on that plumbing. The `--custom-prompt-file` flag added here gives gh-aw a plumbing-independent way to pass the custom prompt.

Closes #688 (this-repo scope).