### PR TITLE
fix(detector): warn when prompt analysis is degraded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ build:
 
 smoke: build
 	# Smoke test the freshly built binary without any container tooling.
+	go test ./cmd/threat-detect -run '^TestRunPassesPromptAnalysisToEngine$$'
 	./bin/$(BINARY_NAME) --version
 
 test:

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ be available on the runner where the binary runs.
 <artifacts-dir>/
 ├── aw-prompts/
 │   ├── prompt.txt          # Expanded workflow prompt file
-│   ├── prompt-template.txt # Pre-expansion prompt template (optional)
-│   └── prompt-import-tree.json # Runtime-import provenance (optional)
+│   ├── prompt-template.txt # Pre-expansion prompt template
+│   └── prompt-import-tree.json # Runtime-import provenance
 ├── agent_output.json       # Agent structured output
 ├── aw_info.json            # Activation metadata (optional)
 ├── aw-*.patch              # Git format-patch files (optional)
@@ -216,6 +216,11 @@ be available on the runner where the binary runs.
 └── comment-memory/         # Agent comment memory (optional)
     └── *.md
 ```
+
+Integrated hosts must stage all three files under `aw-prompts/`. Direct callers
+may omit the template or import tree, but the detector emits an
+`ERR_VALIDATION` warning because trusted-vs-untrusted prompt analysis is then
+degraded. Empty or unreadable analysis files produce the same warning.
 
 ### Output (JSON)
 

--- a/cmd/threat-detect/logfile_test.go
+++ b/cmd/threat-detect/logfile_test.go
@@ -96,6 +96,88 @@ func TestRunWritesJSONLLog(t *testing.T) {
 	}
 }
 
+func TestRunWarnsWhenPromptAnalysisArtifactsAreMissing(t *testing.T) {
+	artifactsDir := t.TempDir()
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	logPath := filepath.Join(t.TempDir(), "run.jsonl")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, copilotMarker, sinkJSON, 0)
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		"-log-file", logPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+	if code != exitSafe {
+		t.Fatalf("run() exit code = %d, want %d", code, exitSafe)
+	}
+	for _, want := range []string{
+		"::warning::ERR_VALIDATION:",
+		"aw-prompts/prompt-template.txt",
+		"aw-prompts/prompt-import-tree.json",
+		"Trusted-vs-untrusted prompt analysis is degraded",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+
+	record := findRecord(readJSONLRecords(t, logPath), "prompt_analysis_degraded")
+	if record == nil {
+		t.Fatal("missing prompt_analysis_degraded runlog event")
+	}
+	if record["level"] != "warning" {
+		t.Errorf("warning level = %v, want warning", record["level"])
+	}
+	if record["error_code"] != "ERR_VALIDATION" {
+		t.Errorf("error_code = %v, want ERR_VALIDATION", record["error_code"])
+	}
+	unavailable, ok := record["unavailable_artifacts"].([]any)
+	if !ok || len(unavailable) != 2 {
+		t.Errorf("unavailable_artifacts = %#v, want two entries", record["unavailable_artifacts"])
+	}
+}
+
+func TestRunWarnsWhenPromptAnalysisArtifactIsEmpty(t *testing.T) {
+	artifactsDir := t.TempDir()
+	promptsDir := filepath.Join(artifactsDir, "aw-prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatalf("creating prompts directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(promptsDir, "prompt-template.txt"), nil, 0o600); err != nil {
+		t.Fatalf("writing empty prompt template: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(promptsDir, "prompt-import-tree.json"), []byte(`{"version":1}`), 0o600); err != nil {
+		t.Fatalf("writing import tree: %v", err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, copilotMarker, sinkJSON, 0)
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+	if code != exitSafe {
+		t.Fatalf("run() exit code = %d, want %d", code, exitSafe)
+	}
+	if !strings.Contains(stderr, "Missing or unusable prompt analysis artifacts: aw-prompts/prompt-template.txt.") {
+		t.Fatalf("stderr missing empty-artifact warning:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "prompt-import-tree.json.") {
+		t.Fatalf("stderr incorrectly reported usable import tree:\n%s", stderr)
+	}
+}
+
 func TestRunUsesLogFileEnvVar(t *testing.T) {
 	artifactsDir := t.TempDir()
 	outputPath := filepath.Join(t.TempDir(), "result.json")

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/github/gh-aw-threat-detection/pkg/artifacts"
 	"github.com/github/gh-aw-threat-detection/pkg/detector"
@@ -39,6 +40,7 @@ const (
 	detectionCorrectionPrefix      = "Your previous response did not record a verdict"
 	detectionCorrectionMessage     = "The threat_detection_result command was not run, or it reported an error and exited before a verdict was recorded."
 	detectionCorrectionInstruction = "Run the threat_detection_result command exactly once with --prompt-injection, --secret-leak, and --malicious-patch each set to true or false, plus a --reason for every threat set to true."
+	promptAnalysisValidationCode   = "ERR_VALIDATION"
 )
 
 // statusPrefix is the marker for the single machine-readable status line
@@ -205,13 +207,14 @@ func run() (code int) {
 		promptTemplate = string(data)
 	}
 
-	prompt, err := detector.BuildPrompt(arts, promptTemplate)
+	prompt, promptAnalysis, err := detector.BuildPromptWithAnalysis(arts, promptTemplate)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error building prompt: %v\n", err)
 		logger.Error("prompt_build_failed", map[string]any{"error": err.Error()})
 		reason = reasonConfigError
 		return exitError
 	}
+	warnDegradedPromptAnalysis(promptAnalysis, logger)
 	logger.Info("prompt_built", map[string]any{"prompt_bytes": len(prompt)})
 
 	// Create engine
@@ -262,6 +265,30 @@ func run() (code int) {
 	code, resultReason = writeResult(result, outputJSON)
 	reason = resultReason
 	return code
+}
+
+func warnDegradedPromptAnalysis(analysis *detector.PromptAnalysis, logger *runlog.Logger) {
+	var unavailable []string
+	if analysis == nil || analysis.PromptTemplate == "" {
+		unavailable = append(unavailable, "aw-prompts/prompt-template.txt")
+	}
+	if analysis == nil || analysis.ImportTree == "" {
+		unavailable = append(unavailable, "aw-prompts/prompt-import-tree.json")
+	}
+	if len(unavailable) == 0 {
+		return
+	}
+
+	fmt.Fprintf(
+		os.Stderr,
+		"::warning::%s: Missing or unusable prompt analysis artifacts: %s. Trusted-vs-untrusted prompt analysis is degraded; ensure the host stages both non-empty files.\n",
+		promptAnalysisValidationCode,
+		strings.Join(unavailable, ", "),
+	)
+	logger.Warning("prompt_analysis_degraded", map[string]any{
+		"error_code":            promptAnalysisValidationCode,
+		"unavailable_artifacts": unavailable,
+	})
 }
 
 func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath string, retries int, logger *runlog.Logger) (*detector.Result, error) {

--- a/cmd/threat-detect/main_test.go
+++ b/cmd/threat-detect/main_test.go
@@ -39,6 +39,63 @@ func TestRunInvokesAgenticEngine(t *testing.T) {
 	}
 }
 
+func TestRunPassesPromptAnalysisToEngine(t *testing.T) {
+	artifactsDir := t.TempDir()
+	promptsDir := filepath.Join(artifactsDir, "aw-prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatalf("creating prompts directory: %v", err)
+	}
+	files := map[string]string{
+		"prompt-template.txt":     "Trusted instructions.\nRequest: {{user_input}}\nEnd.",
+		"prompt.txt":              "Trusted instructions.\nRequest: inspect this issue\nEnd.",
+		"prompt-import-tree.json": `{"version":1,"children":[]}`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(promptsDir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(artifactsDir, "agent_output.json"), []byte(`{"items":[]}`), 0o600); err != nil {
+		t.Fatalf("writing agent output: %v", err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	promptCapture := filepath.Join(t.TempDir(), "engine-prompt.txt")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotCapturingPrompt(t, copilotMarker, promptCapture, sinkJSON)
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+	if code != exitSafe {
+		t.Fatalf("run() exit code = %d, want %d", code, exitSafe)
+	}
+	if strings.Contains(stderr, "prompt analysis artifacts") {
+		t.Fatalf("unexpected degraded-analysis warning:\n%s", stderr)
+	}
+
+	prompt, err := os.ReadFile(promptCapture)
+	if err != nil {
+		t.Fatalf("reading captured engine prompt: %v", err)
+	}
+	for _, want := range []string{
+		"## Prompt Analysis (Trusted vs Untrusted Content)",
+		"### Prompt Template (pre-interpolation)",
+		"### Import Tree (runtime-import provenance)",
+		"### Extracted Untrusted Inputs",
+		"inspect this issue",
+	} {
+		if !strings.Contains(string(prompt), want) {
+			t.Errorf("engine prompt missing %q", want)
+		}
+	}
+}
+
 func TestRunPrefersSinkResultOverTranscript(t *testing.T) {
 	artifactsDir := t.TempDir()
 	outputPath := filepath.Join(t.TempDir(), "result.json")
@@ -263,6 +320,24 @@ func writeFakeCopilotWithSinkAndStdout(t *testing.T, markerPath, sinkJSON, stdou
 	}
 	lines = append(lines, "")
 	if err := os.WriteFile(scriptPath, []byte(strings.Join(lines, "\n")), 0o700); err != nil {
+		t.Fatalf("writing fake copilot: %v", err)
+	}
+	return binDir
+}
+
+func writeFakeCopilotCapturingPrompt(t *testing.T, markerPath, promptPath, sinkJSON string) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	scriptPath := filepath.Join(binDir, "copilot")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"cat > " + shellQuote(promptPath),
+		"printf called > " + shellQuote(markerPath),
+		"printf '%s' " + shellQuote(sinkJSON) + " > \"$THREAT_DETECTION_RESULT_FILE\"",
+		"",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
 		t.Fatalf("writing fake copilot: %v", err)
 	}
 	return binDir

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -29,11 +29,18 @@ func DefaultPromptTemplate() (string, error) {
 // If promptTemplate is empty, the built-in default template is used.
 // The prompt analysis (untrusted input breakdown) is included when available.
 func BuildPrompt(arts *artifacts.Artifacts, promptTemplate string) (string, error) {
+	prompt, _, err := BuildPromptWithAnalysis(arts, promptTemplate)
+	return prompt, err
+}
+
+// BuildPromptWithAnalysis constructs the detection prompt and returns the exact
+// static analysis used to render it.
+func BuildPromptWithAnalysis(arts *artifacts.Artifacts, promptTemplate string) (string, *PromptAnalysis, error) {
 	if promptTemplate == "" {
 		var err error
 		promptTemplate, err = DefaultPromptTemplate()
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 	}
 
@@ -58,5 +65,5 @@ func BuildPrompt(arts *artifacts.Artifacts, promptTemplate string) (string, erro
 		prompt += "\n\n## Additional Instructions\n\n" + arts.CustomPrompt
 	}
 
-	return prompt, nil
+	return prompt, analysis, nil
 }

--- a/pkg/detector/static.go
+++ b/pkg/detector/static.go
@@ -45,7 +45,7 @@ func BuildPromptAnalysis(arts *artifacts.Artifacts) *PromptAnalysis {
 	// Load prompt template if available.
 	if arts.PromptTemplatePath != "" {
 		data, err := os.ReadFile(arts.PromptTemplatePath)
-		if err == nil {
+		if err == nil && strings.TrimSpace(string(data)) != "" {
 			analysis.PromptTemplate = string(data)
 		}
 	}
@@ -53,7 +53,7 @@ func BuildPromptAnalysis(arts *artifacts.Artifacts) *PromptAnalysis {
 	// Load import tree if available.
 	if arts.PromptImportTreePath != "" {
 		data, err := os.ReadFile(arts.PromptImportTreePath)
-		if err == nil {
+		if err == nil && strings.TrimSpace(string(data)) != "" {
 			analysis.ImportTree = string(data)
 		}
 	}

--- a/pkg/runlog/runlog.go
+++ b/pkg/runlog/runlog.go
@@ -23,8 +23,9 @@ import (
 
 // Log levels emitted in the "level" field.
 const (
-	LevelInfo  = "info"
-	LevelError = "error"
+	LevelInfo    = "info"
+	LevelWarning = "warning"
+	LevelError   = "error"
 )
 
 // Logger writes newline-delimited JSON log records to an underlying writer.
@@ -65,6 +66,11 @@ func Open(path string) (*Logger, error) {
 // Info appends an info-level record for event with the given fields.
 func (l *Logger) Info(event string, fields map[string]any) {
 	l.emit(LevelInfo, event, fields)
+}
+
+// Warning appends a warning-level record for event with the given fields.
+func (l *Logger) Warning(event string, fields map[string]any) {
+	l.emit(LevelWarning, event, fields)
 }
 
 // Error appends an error-level record for event with the given fields.

--- a/pkg/runlog/runlog_test.go
+++ b/pkg/runlog/runlog_test.go
@@ -18,11 +18,12 @@ func TestLoggerWritesJSONLRecords(t *testing.T) {
 	l.now = func() time.Time { return fixed }
 
 	l.Info("run_start", map[string]any{"engine": "copilot", "retries": 1})
+	l.Warning("prompt_analysis_degraded", map[string]any{"error_code": "ERR_VALIDATION"})
 	l.Error("detection_failed", map[string]any{"reason": "engine_error"})
 
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d: %q", len(lines), buf.String())
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), buf.String())
 	}
 
 	var first map[string]any
@@ -42,12 +43,20 @@ func TestLoggerWritesJSONLRecords(t *testing.T) {
 		t.Errorf("engine = %v, want copilot", first["engine"])
 	}
 
-	var second map[string]any
-	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+	var warning map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &warning); err != nil {
 		t.Fatalf("line 1 is not valid JSON: %v", err)
 	}
-	if second["level"] != LevelError {
-		t.Errorf("level = %v, want %s", second["level"], LevelError)
+	if warning["level"] != LevelWarning {
+		t.Errorf("level = %v, want %s", warning["level"], LevelWarning)
+	}
+
+	var third map[string]any
+	if err := json.Unmarshal([]byte(lines[2]), &third); err != nil {
+		t.Fatalf("line 2 is not valid JSON: %v", err)
+	}
+	if third["level"] != LevelError {
+		t.Errorf("level = %v, want %s", third["level"], LevelError)
 	}
 }
 
@@ -98,6 +107,7 @@ func TestNilLoggerIsNoOp(t *testing.T) {
 	var l *Logger
 	// None of these must panic.
 	l.Info("evt", map[string]any{"a": 1})
+	l.Warning("evt", nil)
 	l.Error("evt", nil)
 	if err := l.Close(); err != nil {
 		t.Fatalf("Close() on nil logger error = %v", err)

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -154,7 +154,9 @@ threat-detection:
 ```
 <artifacts-dir>/
 ├── aw-prompts/
-│   └── prompt.txt          # Workflow prompt file
+│   ├── prompt.txt                # Rendered workflow prompt
+│   ├── prompt-template.txt       # Pre-interpolation template
+│   └── prompt-import-tree.json   # Runtime-import provenance
 ├── agent_output.json       # Agent structured output
 ├── aw-*.patch              # Git format-patch files (optional)
 ├── aw-*.bundle             # Git bundle files (optional)
@@ -163,6 +165,13 @@ threat-detection:
 ```
 
 **TD-18**: The detector MUST NOT require all artifact files to be present. Missing optional files MUST be handled gracefully.
+
+**TD-18a**: If `aw-prompts/prompt-template.txt` or
+`aw-prompts/prompt-import-tree.json` is absent, unreadable, or empty, the
+detector MUST continue with degraded trusted-vs-untrusted prompt analysis and MUST emit an
+`ERR_VALIDATION` warning to the job log. When structured run logging is enabled,
+it MUST also emit a warning-level `prompt_analysis_degraded` event identifying
+the unavailable artifacts.
 
 ### 8.2 Output Contract
 

--- a/specs/usage-spec.md
+++ b/specs/usage-spec.md
@@ -97,6 +97,23 @@ where `<artifacts-dir>` conforms to the artifacts directory shape (per TD-17)
 and the host MUST NOT require all optional artifact files to be present (per
 TD-18).
 
+**U-06a**: An integrated host preparing the detector's staged artifacts directory
+MUST copy all three prompt artifacts emitted by the guarded agent job:
+
+```
+<artifacts-dir>/aw-prompts/
+├── prompt.txt
+├── prompt-template.txt
+└── prompt-import-tree.json
+```
+
+`prompt-template.txt` is the trusted pre-interpolation template, and
+`prompt-import-tree.json` records runtime-import provenance. The detector uses
+both to distinguish trusted instructions from untrusted runtime content. If
+either analysis artifact is absent, unreadable, or empty, the detector MUST
+continue with degraded analysis and MUST emit an `ERR_VALIDATION` warning to the job log and a
+`prompt_analysis_degraded` warning event to the structured run log when enabled.
+
 **U-07**: The host MUST ensure the AI engine CLI selected via `--engine` (per
 TD-13) and its authentication (per TD-23) are available on `PATH` on the runner
 where the detector executes. The detector MUST NOT be expected to bundle the


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ711KS8CPWWQ80G3K6JFA88)

Closes #686

## Summary
- emit an `ERR_VALIDATION` workflow warning and warning-level runlog event when prompt analysis artifacts are missing, empty, or unreadable
- assert in the smoke target that the engine receives populated trusted-vs-untrusted prompt analysis
- make prompt template and import-tree staging normative in the usage and behavior specs

## Validation
- `make fmt-check lint build test smoke`