### PR TITLE
docs(readme): clarify AWF proxy enforces detection credit cap and sources aic

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,11 @@ the detector, not inside it:
   `max-turns` value that bounds the agentic loop (see the [spec](specs/threat-detection-spec.md), TD-14).
 
 A plain, non-AWF `./bin/threat-detect` invocation (no API proxy) has **no**
-credit cap and produces no proxy token log — only early termination and
-`max-turns` bound its cost.
+credit cap and produces no proxy token log. It is not bounded by `max-turns`
+either — that is a `gh-aw` workflow setting, and the CLI neither accepts it nor
+forwards one to the engine. Only **early termination** (cancelling the engine as
+soon as a verdict is recorded) and the engine's own built-in limits bound its
+cost.
 
 **Where does the `aic` (AI credits) figure come from?** Not from `threat-detect`.
 On the AWF path the proxy records every steered model request to

--- a/README.md
+++ b/README.md
@@ -163,9 +163,20 @@ agentic run it guards. It builds its own prompt and runs the selected engine
 The cost is billed to the same engine account/credentials used for detection
 (`COPILOT_GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY`).
 
-**Is there a separate token cap for the detection job?** There is no token-budget
-cap enforced by this component. Two mechanisms bound the detection pass's cost:
+**Is there a separate token cap for the detection job?** `threat-detect` itself
+enforces no credit budget — it has no notion of AI credits and does not read or
+count tokens. On the path `gh-aw` actually ships, the cap is enforced **around**
+the detector, not inside it:
 
+- **AWF API-proxy `maxAiCredits`** — when `threat-detect` runs under the
+  Agentic Workflow Firewall with the API proxy and token steering enabled
+  (`apiProxy.enabled` + `enableTokenSteering`), the compiled detection step sets
+  `apiProxy.maxAiCredits` from `max-ai-credits` (default 400, or
+  `vars.GH_AW_DEFAULT_DETECTION_MAX_AI_CREDITS`). The proxy enforces this as a
+  **cumulative** per-run credit counter, so it bounds the whole pass —
+  **including `--retries`**, not just the first attempt. This is the enforcement
+  mechanism for the external detector path; there is no `threat-detect`-side
+  budget flag to plumb.
 - **Early termination** — as soon as the model records a verdict through the
   `threat_detection_result` tool, the detector cancels the engine subprocess, so
   the pass stops at the first valid verdict instead of running to the engine's
@@ -173,8 +184,21 @@ cap enforced by this component. Two mechanisms bound the detection pass's cost:
 - **`max-turns`** — `gh-aw`'s `threat-detection.engine` configuration accepts a
   `max-turns` value that bounds the agentic loop (see the [spec](specs/threat-detection-spec.md), TD-14).
 
-For authoritative billing, use the engine's own logs (uploaded as the detection
-log artifact) together with `gh-aw`'s `logs` tooling.
+A plain, non-AWF `./bin/threat-detect` invocation (no API proxy) has **no**
+credit cap and produces no proxy token log — only early termination and
+`max-turns` bound its cost.
+
+**Where does the `aic` (AI credits) figure come from?** Not from `threat-detect`.
+On the AWF path the proxy records every steered model request to
+`token-usage.jsonl` under `…/sandbox/firewall/**/api-proxy-logs/`, and `gh-aw`'s
+`parse_token_usage.cjs` aggregates those records into the detection job's `aic`
+output and `agent_usage.json`. That figure is therefore **independent of**
+`threat-detect`'s engine flags and of any diagnostics it interleaves into
+`detection.log`; the detector's stdout is not the source of truth for credits.
+
+For authoritative billing, use the AWF proxy token log / `agent_usage.json` (or
+the engine's own logs, uploaded as the detection log artifact) together with
+`gh-aw`'s `logs` tooling.
 
 ### Released binary
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ729NSV5324VKSZVBYG9BY5)

Closes #698

## Summary

Corrects the README "AI Credits and Token Usage" section in light of the investigation on #698.

The section previously claimed there was "no token-budget cap enforced by this component" and implied `aic`/billing derives from the engine's own detection logs. Investigation of the compiled standalone smoke locks and the current `gh-aw` action scripts shows that, on the external AWF path we actually ship:

- **`max-ai-credits` *is* enforced** — the compiled detection step sets `apiProxy.maxAiCredits` (from `max-ai-credits`, default 400) and the AWF API proxy enforces it as a **cumulative** per-run counter, so it bounds the whole pass including `--retries`.
- **`aic` is proxy-sourced** — [`parse_token_usage.cjs`](https://github.com/github/gh-aw/blob/main/actions/setup/js/parse_token_usage.cjs) aggregates the proxy's `…/api-proxy-logs/token-usage.jsonl`, **not** `threat-detect`'s stdout/`detection.log`. So `aic` is independent of our engine flags and interleaved diagnostics — engine-flag drift cannot silently empty it.

The updated docs also note the residual caveat: a plain, non-AWF `./bin/threat-detect` invocation has neither the credit cap nor a proxy token log.

## Why docs-only

`threat-detect` has no notion of AI credits and never has. The enforcement and accounting both live in the AWF proxy / `gh-aw` on the path that ships, so there is no `threat-detect`-side budget flag to plumb. See the detailed findings comment on #698.

## Testing

Documentation-only change; no code, build, or test impact.

Refs #698.