### PR TITLE
docs(devguide): drop stale transcript-scraping fallback claim

### DIFF
--- a/.github/workflows/replay-detection.yml
+++ b/.github/workflows/replay-detection.yml
@@ -484,7 +484,9 @@ jobs:
           if runlogs:
               (output_root / 'original-detection-runlog.jsonl').write_bytes(runlogs[0].read_bytes())
           candidates = list(root.rglob('detection.log')) + list(root.rglob('*.log'))
-          marker = re.compile(r'THREAT_DETECTION_RESULT:(\{.*\})')
+          # Diagnostic-only: parses the *original* gh-aw run's log, which may
+          # carry the legacy marker wrapped in Markdown emphasis (**/__/*/_).
+          marker = re.compile(r'THREAT_DETECTION_RESULT:\s*(\{.*\})')
           for path in candidates:
               for line in path.read_text(errors='replace').splitlines():
                   match = marker.search(line)

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -123,14 +123,16 @@ post-hoc transcript scraping:
   cancels the engine subprocess as soon as a valid result is recorded (early
   termination). A subprocess kill is treated as success when a valid sink result
   exists.
-- `analyzeWithRetries` prefers the sink result (`detector.ReadResultFile`) and
-  only falls back to `detector.ParseResult` transcript scraping when the sink is
-  absent or invalid. Helpers live in `pkg/detector/result.go`
-  (`WriteResultFile`, `ReadResultFile`, `BuildResultFromReport`,
-  `ValidateReportFields`).
-- Claude is invoked with `--allowed-tools Bash` when the sink is enabled so it
-  can execute the wrapper; engines that cannot run shell tools fall back to the
-  legacy `THREAT_DETECTION_RESULT:{...}` transcript line, which remains supported.
+- `analyzeWithRetries` reads the verdict exclusively from the sink
+  (`detector.ReadResultFile`). The engine transcript is never scraped for a
+  verdict; a run that records no valid sink result is retried and, on retry
+  exhaustion, fails closed as an infrastructure error. Helpers live in
+  `pkg/detector/result.go` (`WriteResultFile`, `ReadResultFile`,
+  `BuildResultFromReport`, `ValidateReportFields`).
+- Claude is invoked with `--allowed-tools Bash` so it can execute the wrapper.
+  An engine that cannot run the wrapper has no fallback channel: the legacy
+  `THREAT_DETECTION_RESULT:{...}` transcript line is not parsed by this repo
+  (`TestRunPrefersSinkResultOverTranscript` guards against reintroducing it).
 
 ### Safe Outputs Context
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ99WHGH2QN2R5ZXK9M4NBMQ)

Closes #756

Triage of #756 (gh-aw parity): upstream [gh-aw#50401](https://github.com/github/gh-aw/pull/50401) makes gh-aw's parser accept Markdown-emphasis-wrapped `THREAT_DETECTION_RESULT` lines.

## Verdict: that change does not apply to this repo

The detector reads its verdict **exclusively** from the out-of-band result sink written by the `threat_detection_result` tool. It never scrapes the engine transcript:

- No `ParseResult` exists in the Go code — only `ParseStructuredResult`, fed by `detector.ReadResultFile`.
- `TestRunPrefersSinkResultOverTranscript` plants a *conflicting* legacy `THREAT_DETECTION_RESULT:{...}` line on stdout and asserts it is ignored.
- `TestRunEngineFailsWithoutSinkResult` asserts we fail closed even when stdout carries a well-formed legacy line.
- `conclude.go`'s `detectionLogMarkers` only *echoes* those lines as diagnostics; TD-20d forbids deriving the verdict from the detection log.

## What this PR does change

Two stale / edge spots found during the check:

1. **`DEVGUIDE.md`** still claimed `analyzeWithRetries` "falls back to `detector.ParseResult` transcript scraping" and that the legacy line "remains supported". Both are untrue — corrected to describe sink-only reading and fail-closed retry exhaustion.
2. **`.github/workflows/replay-detection.yml`** parses the *original gh-aw run's* log to build the replay comparison baseline. That is the one place upstream's line format can reach us, so the diagnostic-only regex now tolerates whitespace after the colon, making `**THREAT_DETECTION_RESULT: {...}**` parse. Verified against plain, `**`, and `__` variants.

No behavior change to the detector or the JSON result contract.

## Validation

`make fmt lint build test` passes.