### PR TITLE
fix(detector): make artifact inventory step summary write non-fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ threat-detect [flags] <artifacts-dir>
 - `--custom-prompt-file` — Path to a file with additional detection instructions. Takes precedence over `--custom-prompt` and `CUSTOM_PROMPT`
 - `--output` — Path to write JSON result (defaults to stdout)
 - `--log-file` — Path to write structured JSONL run logs (one JSON object per line). Env: `THREAT_DETECTION_LOG_FILE`; defaults to `detection-runlog.jsonl` beside `--output`
-- `--step-summary` — Path to append the rendered prompt (engine/model/retries plus the prompt actually sent, including the resolved prompt-analysis section) as a collapsible block in the job step summary. Defaults to `GITHUB_STEP_SUMMARY`
+- `--step-summary` — Path to append the artifact inventory table and the rendered prompt (engine/model/retries plus the prompt actually sent, including the resolved prompt-analysis section, as a collapsible block) in the job step summary. Defaults to `GITHUB_STEP_SUMMARY`. Best effort: a failed write warns and never fails detection
 - `--retries` — Retries for malformed detection outputs. Default: `1` (env: `THREAT_DETECTION_RETRIES`)
 - `--version` — Print version and exit
 
@@ -333,8 +333,10 @@ engine runs. Findings about other artifacts stay advisory warnings in both
 modes.
 
 Every file below the artifacts directory is recorded with its size and consumed
-status in the JSONL `artifacts_loaded` event and, when `GITHUB_STEP_SUMMARY` is
-set, in the Actions step summary. Only an allowlisted, size-bounded subset of
+status in the JSONL `artifacts_loaded` event and, when a step summary path is
+configured (`--step-summary`, defaulting to `GITHUB_STEP_SUMMARY`), in the
+Actions step summary. A step summary that cannot be written is reported as a
+warning and never fails detection. Only an allowlisted, size-bounded subset of
 `aw_info.json` is added to the detection prompt, and all of its values are
 explicitly treated as untrusted runtime data.
 

--- a/cmd/threat-detect/logfile_test.go
+++ b/cmd/threat-detect/logfile_test.go
@@ -432,8 +432,12 @@ func TestRunRejectsUnopenableLogFile(t *testing.T) {
 	}
 }
 
-func TestRunRejectsUnwritableStepSummary(t *testing.T) {
+// An unwritable step summary is a best-effort diagnostic failure (TD-20c): it
+// must warn and let detection continue, not abort as a configuration error.
+// Under AWF the inherited GITHUB_STEP_SUMMARY path is outside the sandbox.
+func TestRunWarnsOnUnwritableStepSummary(t *testing.T) {
 	artifactsDir := t.TempDir()
+	writeMinimalArtifacts(t, artifactsDir)
 	logPath := filepath.Join(t.TempDir(), "run.jsonl")
 	summaryPath := filepath.Join(t.TempDir(), "missing-dir", "summary.md")
 
@@ -445,17 +449,18 @@ func TestRunRejectsUnwritableStepSummary(t *testing.T) {
 		"GITHUB_STEP_SUMMARY": summaryPath,
 	})
 
-	if code != exitError {
-		t.Fatalf("run() exit code = %d, want %d", code, exitError)
+	if code == exitError && strings.Contains(stderr, "reason=config_error") {
+		t.Fatalf("step summary failure must not be a config error, got:\n%s", stderr)
 	}
-	if !strings.Contains(stderr, "Error writing artifact inventory summary") {
-		t.Fatalf("stderr missing summary error, got:\n%s", stderr)
-	}
-	if !strings.Contains(stderr, "reason=config_error") {
-		t.Fatalf("stderr missing config_error status, got:\n%s", stderr)
+	if !strings.Contains(stderr, "Warning: failed to write artifact inventory summary") {
+		t.Fatalf("stderr missing summary warning, got:\n%s", stderr)
 	}
 	records := readJSONLRecords(t, logPath)
 	if findRecord(records, "artifact_inventory_summary_failed") == nil {
 		t.Fatalf("missing artifact_inventory_summary_failed record: %#v", records)
+	}
+	// Detection proceeded past the summary write to the engine invocation.
+	if findRecord(records, "prompt_built") == nil {
+		t.Fatalf("expected run to continue after step summary failure: %#v", records)
 	}
 }

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -227,11 +227,15 @@ func run() (code int) {
 		"patch_files":                len(arts.PatchFiles),
 		"all_primary_inputs_missing": arts.AllPrimaryInputsMissing,
 	})
-	if err := stepsummary.WriteArtifactInventory(os.Getenv("GITHUB_STEP_SUMMARY"), arts.Inventory); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing artifact inventory summary: %v\n", err)
+	// The step summary is a best-effort diagnostic, so a failed write must not
+	// abort detection. Under AWF the inherited GITHUB_STEP_SUMMARY can name a
+	// runner path that is not mounted inside the sandbox; treating that as a
+	// configuration error would fail the whole detection job for an
+	// observability artifact. This mirrors the prompt summary (TD-20g) and the
+	// verdict summary (TD-20h), which are already best-effort.
+	if err := stepsummary.WriteArtifactInventory(stepSummary, arts.Inventory); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to write artifact inventory summary: %v\n", err)
 		logger.Error("artifact_inventory_summary_failed", map[string]any{"error": err.Error()})
-		reason = reasonConfigError
-		return exitError
 	}
 
 	// Degraded inputs (missing/empty prompt or agent output, an expected but

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -275,9 +275,11 @@ per TD-18c) non-mandatory failures MUST
 surface as warnings without failing the job, except that `agent_failure` and
 `parse_error` MUST hard-fail when the detection execution step itself failed.
 
-**TD-20c**: When `GITHUB_STEP_SUMMARY` is set, the detector MUST append the
-artifact inventory defined by TD-17b as a Markdown table. Failure to write the
-configured summary MUST be treated as a configuration error.
+**TD-20c**: When a step summary path is configured (the `--step-summary` flag,
+defaulting to the `GITHUB_STEP_SUMMARY` environment variable), the detector MUST
+append the artifact inventory defined by TD-17b as a Markdown table. A failure to
+write the step summary MUST NOT fail the run; it is a best-effort diagnostic aid
+and MUST be reported as a warning and recorded in the run log (TD-20a).
 
 **TD-20d**: The `conclude` subcommand MUST write a human-readable diagnostic
 section to standard output that is sufficient, on its own, to explain the

--- a/specs/usage-spec.md
+++ b/specs/usage-spec.md
@@ -156,7 +156,9 @@ verdict payload and MUST read it from the location it configured (stdout, or the
 writes `detection-runlog.jsonl` in the result file's directory. The host MUST NOT
 point `--log-file` and `--output` at the same path. In GitHub Actions, the host
 SHOULD provide `GITHUB_STEP_SUMMARY` so the recursive artifact inventory is
-visible in the run summary (per TD-20c).
+visible in the run summary (per TD-20c). When the detector runs sandboxed (for
+example under AWF), the host SHOULD point that path at a location writable
+inside the sandbox; an unwritable step summary is a warning, not a failure.
 
 ### 3.1 Flags
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ9G01RVJ1NB3NY8PNA7BHBP)

## Problem

Every smoke workflow — Copilot, Claude, and Codex alike — was failing in the detection job at **Execute threat detection with AWF**:

```
Error writing artifact inventory summary: opening GITHUB_STEP_SUMMARY:
  open /home/runner/work/_temp/_runner_file_commands/step_summary_…: no such file or directory
THREAT_DETECTION_STATUS: reason=config_error exit=2
```

Detection aborted with exit `2` before the engine ever ran, so no `detection_result.json` was produced and `conclude` then hard-failed with `ERR_SYSTEM: Detection result file not found`.

Failing runs: [31028286368](https://github.com/github/gh-aw-threat-detection/actions/runs/31028286368), [31028288393](https://github.com/github/gh-aw-threat-detection/actions/runs/31028288393), [31028290428](https://github.com/github/gh-aw-threat-detection/actions/runs/31028290428).

## Root cause

Confirmed from the AWF compose file in the run's audit artifacts:

```yaml
environment:
  GITHUB_STEP_SUMMARY: /home/runner/work/_temp/_runner_file_commands/step_summary_…
volumes:
  - /tmp:/tmp:rw
  - /tmp/awf-…-chroot-home:/host/home/runner:rw   # empty home overlay
```

* `/home/runner/work/_temp` is not mounted into the sandbox, and `/home/runner` is overlaid by an empty home volume, so the inherited path cannot be opened. That is deliberate AWF isolation — mounting `_runner_file_commands` rw would let a sandboxed agent inject `GITHUB_ENV` / `GITHUB_OUTPUT` / `GITHUB_STEP_SUMMARY` into the host workflow, so it must stay unmounted.
* gh-aw's step-level `GITHUB_STEP_SUMMARY: /tmp/gh-aw/agent-step-summary.md` override never reaches the process: the runner re-injects the real file-command variable for `run:` steps and AWF forwards the actual process env via `--env-all`.

The spec itself mandated the fatal behavior — TD-20c said a failed summary write "MUST be treated as a configuration error" — which contradicts TD-20g (prompt summary) and TD-20h (verdict summary), both already best-effort.

## Change

* `cmd/threat-detect/main.go`: an inventory step-summary write failure now warns on stderr, records `artifact_inventory_summary_failed` in the JSONL run log, and lets detection continue. It also resolves the path from `--step-summary` (which already defaults to `GITHUB_STEP_SUMMARY`) instead of reading the env directly, so the flag actually applies and the existing `--output` / `--log-file` path-collision validation covers it.
* `specs/threat-detection-spec.md` TD-20c and `specs/usage-spec.md` U-09 updated to match, aligning with TD-20g/TD-20h.
* `README.md`: `--step-summary` now documents the inventory table and the best-effort semantics.
* `TestRunRejectsUnwritableStepSummary` → `TestRunWarnsOnUnwritableStepSummary`, asserting the run proceeds past the summary write (`prompt_built` is reached) and does not report `config_error`.

## Follow-up (upstream, not this repo)

The detection step's inventory table is still silently dropped in gh-aw-generated workflows. gh-aw should pass `--step-summary /tmp/gh-aw/threat-detection/step-summary.md` (already mounted rw) and append it afterwards, mirroring the agent job's `touch` + `append_agent_step_summary.sh` pattern — or unset `GITHUB_STEP_SUMMARY` for the sandboxed step. The same evidence indicates the agent job's own redirect is ineffective for the identical reason; it just never errors.

## Validation

`make fmt-check lint build test` all pass.