### PR TITLE
test(engine): make copilot harness AWF config test hermetic

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -305,10 +305,16 @@ const copilotHarnessDefaultAwfConfigPath = "/tmp/gh-aw/awf-config.json"
 // default path exists (the harness will find it there), or when no mounted
 // config can be located.
 func copilotHarnessAwfConfigEnv() []string {
+	return copilotHarnessAwfConfigEnvAt(copilotHarnessDefaultAwfConfigPath)
+}
+
+// copilotHarnessAwfConfigEnvAt implements copilotHarnessAwfConfigEnv against an
+// explicit harness default path so tests can stay hermetic.
+func copilotHarnessAwfConfigEnvAt(harnessDefaultPath string) []string {
 	if strings.TrimSpace(os.Getenv("GH_AW_AWF_CONFIG_PATH")) != "" {
 		return nil
 	}
-	if _, err := os.Stat(copilotHarnessDefaultAwfConfigPath); err == nil {
+	if _, err := os.Stat(harnessDefaultPath); err == nil {
 		return nil
 	}
 	runnerTemp := strings.TrimSpace(os.Getenv("RUNNER_TEMP"))

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -194,26 +194,46 @@ func TestEngineCommandArgs(t *testing.T) {
 		if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
 			t.Fatalf("WriteFile() error = %v", err)
 		}
-		got := copilotHarnessAwfConfigEnv()
+		got := copilotHarnessAwfConfigEnvAt(filepath.Join(t.TempDir(), "missing-awf-config.json"))
 		want := []string{"GH_AW_AWF_CONFIG_PATH=" + configPath}
 		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("copilotHarnessAwfConfigEnv() = %#v, want %#v", got, want)
+			t.Fatalf("copilotHarnessAwfConfigEnvAt() = %#v, want %#v", got, want)
 		}
 	})
 
 	t.Run("copilot harness awf config env respects existing override", func(t *testing.T) {
 		t.Setenv("GH_AW_AWF_CONFIG_PATH", "/custom/awf-config.json")
 		t.Setenv("RUNNER_TEMP", t.TempDir())
-		if got := copilotHarnessAwfConfigEnv(); got != nil {
-			t.Fatalf("copilotHarnessAwfConfigEnv() = %#v, want nil", got)
+		if got := copilotHarnessAwfConfigEnvAt(filepath.Join(t.TempDir(), "missing-awf-config.json")); got != nil {
+			t.Fatalf("copilotHarnessAwfConfigEnvAt() = %#v, want nil", got)
 		}
 	})
 
 	t.Run("copilot harness awf config env nil when no config mounted", func(t *testing.T) {
 		t.Setenv("GH_AW_AWF_CONFIG_PATH", "")
 		t.Setenv("RUNNER_TEMP", t.TempDir())
-		if got := copilotHarnessAwfConfigEnv(); got != nil {
-			t.Fatalf("copilotHarnessAwfConfigEnv() = %#v, want nil", got)
+		if got := copilotHarnessAwfConfigEnvAt(filepath.Join(t.TempDir(), "missing-awf-config.json")); got != nil {
+			t.Fatalf("copilotHarnessAwfConfigEnvAt() = %#v, want nil", got)
+		}
+	})
+
+	t.Run("copilot harness awf config env nil when harness default exists", func(t *testing.T) {
+		t.Setenv("GH_AW_AWF_CONFIG_PATH", "")
+		runnerTemp := t.TempDir()
+		t.Setenv("RUNNER_TEMP", runnerTemp)
+		configPath := filepath.Join(runnerTemp, "gh-aw", "awf-config.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		harnessDefault := filepath.Join(t.TempDir(), "awf-config.json")
+		if err := os.WriteFile(harnessDefault, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if got := copilotHarnessAwfConfigEnvAt(harnessDefault); got != nil {
+			t.Fatalf("copilotHarnessAwfConfigEnvAt() = %#v, want nil", got)
 		}
 	})
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ9H5TDXRJR03HS4ZSFBWDCQ)

Closes #766

## Problem

The daily smoke workflows (e.g. [Smoke Claude Standalone #766](https://github.com/github/gh-aw-threat-detection/issues/766)) reported `make test` failing on:

```
--- FAIL: TestEngineCommandArgs/copilot_harness_awf_config_env_points_at_mounted_config
    copilotHarnessAwfConfigEnv() = []string(nil), want []string{"GH_AW_AWF_CONFIG_PATH=.../gh-aw/awf-config.json"}
```

## Root cause

`copilotHarnessAwfConfigEnv()` stats the hardcoded harness default path `/tmp/gh-aw/awf-config.json` and returns `nil` when it exists. The test set `RUNNER_TEMP` to a temp dir but could not control that hardcoded path, so it only passed on machines where `/tmp/gh-aw/awf-config.json` was absent. On gh-aw runners (which is exactly where the smoke workflows run `make test`) that file exists, so the test failed. Reproduced locally with:

```bash
mkdir -p /tmp/gh-aw && echo '{}' > /tmp/gh-aw/awf-config.json
go test -count=1 ./pkg/engine/ -run TestEngineCommandArgs   # FAIL
```

## Fix

Extract `copilotHarnessAwfConfigEnvAt(harnessDefaultPath string)` so tests can inject a temp harness default path. `copilotHarnessAwfConfigEnv()` is unchanged behaviorally — it just delegates with `copilotHarnessDefaultAwfConfigPath`. Tests now use the injectable variant, plus a new case covering the "harness default exists → nil" branch that was previously untestable.

## Verification

- Reproduced the failure with `/tmp/gh-aw/awf-config.json` present, confirmed it now passes in the same conditions.
- `make fmt lint build test` all pass.