### PR TITLE
chore(smoke): bump standalone-latest detector to v0.4.2

### DIFF
--- a/.github/workflows/smoke-claude-standalone-latest.lock.yml
+++ b/.github/workflows/smoke-claude-standalone-latest.lock.yml
@@ -1452,7 +1452,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.2
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'

--- a/.github/workflows/smoke-codex-standalone-latest.lock.yml
+++ b/.github/workflows/smoke-codex-standalone-latest.lock.yml
@@ -1452,7 +1452,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.2
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'

--- a/.github/workflows/smoke-copilot-standalone-latest.lock.yml
+++ b/.github/workflows/smoke-copilot-standalone-latest.lock.yml
@@ -1388,7 +1388,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.2
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ9H0S634EJHFSX16W2DF6CC)

Bumps the `threat-detect` version pinned in the standalone-latest smoke workflows from `v0.4.0` to `v0.4.2`.

## Changes

- `.github/workflows/smoke-claude-standalone-latest.lock.yml`
- `.github/workflows/smoke-codex-standalone-latest.lock.yml`
- `.github/workflows/smoke-copilot-standalone-latest.lock.yml`

Each now runs `install_threat_detect_binary.sh v0.4.2`.

## Notes

The detector version is baked into exactly one line per lock file (the `install_threat_detect_binary.sh` invocation), which is the only artifact of the patched `constants.DefaultThreatDetectVersion` used when compiling `*-standalone-latest.md`. The edit is therefore equivalent to a full recompile with the patched compiler; the gh-aw `compiler_version` (`v0.85.1`) is unchanged.

After merge, dispatch the top-level **Smoke** workflow to confirm the new detector version runs green.