### PR TITLE
chore(workflows): bump smoke latest detector to v0.4.3

### DIFF
--- a/.github/workflows/smoke-claude-standalone-latest.lock.yml
+++ b/.github/workflows/smoke-claude-standalone-latest.lock.yml
@@ -1452,7 +1452,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.3
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'

--- a/.github/workflows/smoke-codex-standalone-latest.lock.yml
+++ b/.github/workflows/smoke-codex-standalone-latest.lock.yml
@@ -1452,7 +1452,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.3
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'

--- a/.github/workflows/smoke-copilot-standalone-latest.lock.yml
+++ b/.github/workflows/smoke-copilot-standalone-latest.lock.yml
@@ -1388,7 +1388,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.3
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ9HH2B4EC6MRB5H7SSC62PP)

## Summary

Bumps the pinned `threat-detect` version in the **standalone latest** smoke workflows from `v0.4.0` to `v0.4.3` (the newest `github/gh-aw-threat-detection` prerelease).

Affected locks:
- `.github/workflows/smoke-copilot-standalone-latest.lock.yml`
- `.github/workflows/smoke-claude-standalone-latest.lock.yml`
- `.github/workflows/smoke-codex-standalone-latest.lock.yml`

## How

Per the [`update-workflow-versions`](skills/update-workflow-versions/SKILL.md) skill:

1. Cloned `github/gh-aw` at `v0.85.1` (still the newest gh-aw (pre)release, matching the existing `compiler_version` in these locks — no gh-aw bump needed).
2. Patched `constants.DefaultThreatDetectVersion` to `v0.4.3`.
3. Built the compiler with `-X main.version=v0.85.1 -X main.isRelease=true` so the generated headers, `GH_AW_VERSION`, and version-check step match a real release build.
4. Recompiled with `--action-mode action --action-tag v0.85.1 --no-check-update`.

## Verification

The resulting diff is exactly three lines — no compiler-version, metadata, or step drift:

```
-  bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.0
+  bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.4.3
```

(×3, one per lock file)

## Follow-up

After merge, dispatch the top-level **Smoke** workflow to confirm the three latest-detector smokes run green against `v0.4.3`.