### PR TITLE
test(cmd): make step-summary warning test hermetic

### DIFF
--- a/cmd/threat-detect/logfile_test.go
+++ b/cmd/threat-detect/logfile_test.go
@@ -440,6 +440,13 @@ func TestRunWarnsOnUnwritableStepSummary(t *testing.T) {
 	writeMinimalArtifacts(t, artifactsDir)
 	logPath := filepath.Join(t.TempDir(), "run.jsonl")
 	summaryPath := filepath.Join(t.TempDir(), "missing-dir", "summary.md")
+	// This test runs past the step-summary write into the engine invocation, so
+	// the engine must be stubbed. Without a fake copilot on PATH the run would
+	// execute whatever real `copilot` the host provides — which, on a runner
+	// with working engine credentials, starts a live agentic session and hangs
+	// until the package test timeout.
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, filepath.Join(t.TempDir(), "copilot-called"), sinkJSON, 0)
 
 	code, stderr := runWithTestArgsCapture(t, []string{
 		"threat-detect",
@@ -447,6 +454,7 @@ func TestRunWarnsOnUnwritableStepSummary(t *testing.T) {
 		artifactsDir,
 	}, map[string]string{
 		"GITHUB_STEP_SUMMARY": summaryPath,
+		"PATH":                fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 	})
 
 	if code == exitError && strings.Contains(stderr, "reason=config_error") {

--- a/cmd/threat-detect/main_test.go
+++ b/cmd/threat-detect/main_test.go
@@ -426,6 +426,12 @@ func runWithTestArgsCapture(t *testing.T, args []string, env map[string]string) 
 	for key, value := range env {
 		t.Setenv(key, value)
 	}
+	if _, ok := env["PATH"]; !ok {
+		// Keep the package hermetic: a test that reaches the engine without
+		// explicitly stubbing one must not fall through to a real engine CLI on
+		// the host PATH, which can block on network/auth until the test timeout.
+		t.Setenv("PATH", t.TempDir())
+	}
 
 	r, w, err := os.Pipe()
 	if err != nil {


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZ9K1CY9CYFM5DSDD787MZTN)

## Problem

[Smoke Claude Standalone Latest run 31034550307](https://github.com/github/gh-aw-threat-detection/actions/runs/31034550307) failed. The `agent` job ended with `error_max_turns` ("Reached maximum number of turns (20)"), but that was a symptom, not the cause.

The agent burned ~12 of its 20 turns polling a backgrounded `make test`, because that step never finished:

```
panic: test timed out after 10m0s
FAIL	github.com/github/gh-aw-threat-detection/cmd/threat-detect	600.023s
```

### Root cause

`TestRunWarnsOnUnwritableStepSummary` (`cmd/threat-detect/logfile_test.go`) was the only test in the package that runs past the step-summary write into the **engine invocation** without stubbing an engine on `PATH`. It therefore executed whatever real `copilot` binary the host provided:

```
$ go test -v -race ./cmd/threat-detect/ | grep 'engine invoke' | grep -v /tmp/Test
[threat-detect] engine invoke: engine=copilot ... command=copilot (/usr/local/bin/copilot) args=7
```

On a plain CI runner the real `copilot` has no usable credentials and fails in under a second, so CI stayed green. Inside the AWF sandbox used by the standalone smoke workflows the CLI proxy injects working credentials, so the same invocation starts a **live agentic session** that never returns — hanging the package until the 10-minute `go test` timeout and failing `make test`.

## Fix

- Stub a fake `copilot` (via the existing `writeFakeCopilotWithSink` helper) for `TestRunWarnsOnUnwritableStepSummary`, matching every other engine-reaching test in the package.
- Make `runWithTestArgsCapture` default `PATH` to an empty temp dir when a test does not set one, so no future test can silently fall through to a real engine CLI on the host.

No production code changed.

## Verification

- `make fmt-check`, `make lint`, `make build`, `make test` all pass.
- `cmd/threat-detect` package runtime drops from **9.2s → 1.9s**.
- `go test -v ./cmd/threat-detect/ | grep 'engine invoke' | grep -v /tmp/Test` now returns nothing — every engine invocation resolves to a fake under `t.TempDir()`.