### PR TITLE
fix(report): accept space-separated boolean flag values

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ invocation. The model reports its verdict by running the command exactly once:
 threat_detection_result --prompt-injection <true|false> --secret-leak <true|false> --malicious-patch <true|false> --reason "..."
 ```
 
-The command validates the input synchronously: on bad input it prints
+The three boolean flags accept both the space-separated form shown above and the
+`--prompt-injection=true` form. The command validates the input synchronously: on bad input it prints
 `THREAT_DETECTION_RESULT_ERROR:` and exits non-zero without recording anything,
 so the model can correct it in-session; on valid input it atomically records the
 canonical JSON verdict to the sink (first valid write wins, idempotent) and

--- a/cmd/threat-detect/report.go
+++ b/cmd/threat-detect/report.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/github/gh-aw-threat-detection/pkg/detector"
 )
@@ -49,7 +51,7 @@ func runReport(args []string) int {
 	fs.Var(&reasons, "reason", "Reason explaining a detected threat (repeatable)")
 	fs.StringVar(&resultFile, "result-file", os.Getenv("THREAT_DETECTION_RESULT_FILE"), "Path to the result sink file (defaults to env THREAT_DETECTION_RESULT_FILE)")
 
-	if err := fs.Parse(args); err != nil {
+	if err := fs.Parse(normalizeBoolFlagArgs(args)); err != nil {
 		reportError(err.Error())
 		return reportExitInvalid
 	}
@@ -57,7 +59,7 @@ func runReport(args []string) int {
 	// All three boolean flags are required and must be explicitly provided.
 	provided := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { provided[f.Name] = true })
-	for _, name := range []string{"prompt-injection", "secret-leak", "malicious-patch"} {
+	for _, name := range boolReportFlags {
 		if !provided[name] {
 			reportError(fmt.Sprintf("missing required flag --%s (must be true or false)", name))
 			return reportExitInvalid
@@ -95,6 +97,44 @@ func runReport(args []string) int {
 
 	fmt.Println("THREAT_DETECTION_RESULT_RECORDED: analysis complete; stop now and produce no further output.")
 	return reportExitOK
+}
+
+// boolReportFlags are the boolean flags of the report-result subcommand.
+var boolReportFlags = []string{"prompt-injection", "secret-leak", "malicious-patch"}
+
+// normalizeBoolFlagArgs rewrites space-separated boolean flag values
+// (`--prompt-injection true`) into the `--prompt-injection=true` form that Go's
+// flag package requires. The documented tool invocation uses the space-separated
+// form, which flag would otherwise parse as a bare `true` boolean flag followed
+// by a positional argument that silently terminates parsing.
+func normalizeBoolFlagArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			out = append(out, args[i:]...)
+			break
+		}
+		name := strings.TrimLeft(arg, "-")
+		if name != arg && isBoolReportFlag(name) && i+1 < len(args) {
+			if value, err := strconv.ParseBool(args[i+1]); err == nil {
+				out = append(out, arg+"="+strconv.FormatBool(value))
+				i++
+				continue
+			}
+		}
+		out = append(out, arg)
+	}
+	return out
+}
+
+func isBoolReportFlag(name string) bool {
+	for _, candidate := range boolReportFlags {
+		if name == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 // reportError prints a bounded, actionable error to both stdout (so it is visible

--- a/cmd/threat-detect/report_test.go
+++ b/cmd/threat-detect/report_test.go
@@ -80,3 +80,92 @@ func TestRunReportIdempotent(t *testing.T) {
 		t.Fatalf("expected first-write-wins; got %#v", result)
 	}
 }
+
+func TestRunReportSpaceSeparatedBooleans(t *testing.T) {
+	sink := filepath.Join(t.TempDir(), "result.json")
+	t.Setenv("THREAT_DETECTION_RESULT_FILE", sink)
+
+	code := runReport([]string{"--prompt-injection", "false", "--secret-leak", "true", "--malicious-patch", "false", "--reason", "leaked token"})
+	if code != reportExitOK {
+		t.Fatalf("runReport() = %d, want %d", code, reportExitOK)
+	}
+	result, err := detector.ReadResultFile(sink)
+	if err != nil {
+		t.Fatalf("ReadResultFile() error = %v", err)
+	}
+	if result.PromptInjection || !result.SecretLeak || result.MaliciousPatch {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(result.Reasons) != 1 || result.Reasons[0] != "leaked token" {
+		t.Fatalf("unexpected reasons: %#v", result.Reasons)
+	}
+}
+
+func TestRunReportSpaceSeparatedSingleDash(t *testing.T) {
+	sink := filepath.Join(t.TempDir(), "result.json")
+	t.Setenv("THREAT_DETECTION_RESULT_FILE", sink)
+
+	code := runReport([]string{"-prompt-injection", "true", "-secret-leak", "false", "-malicious-patch", "false", "-reason", "injection"})
+	if code != reportExitOK {
+		t.Fatalf("runReport() = %d, want %d", code, reportExitOK)
+	}
+	result, err := detector.ReadResultFile(sink)
+	if err != nil {
+		t.Fatalf("ReadResultFile() error = %v", err)
+	}
+	if !result.PromptInjection {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestNormalizeBoolFlagArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "space separated booleans joined",
+			in:   []string{"--prompt-injection", "true", "--secret-leak", "FALSE", "--malicious-patch", "0"},
+			want: []string{"--prompt-injection=true", "--secret-leak=false", "--malicious-patch=false"},
+		},
+		{
+			name: "equals form untouched",
+			in:   []string{"--prompt-injection=true", "--reason", "x"},
+			want: []string{"--prompt-injection=true", "--reason", "x"},
+		},
+		{
+			name: "reason value that looks boolean untouched",
+			in:   []string{"--reason", "true", "--prompt-injection", "true"},
+			want: []string{"--reason", "true", "--prompt-injection=true"},
+		},
+		{
+			name: "non boolean value untouched",
+			in:   []string{"--prompt-injection", "yes"},
+			want: []string{"--prompt-injection", "yes"},
+		},
+		{
+			name: "terminator stops rewriting",
+			in:   []string{"--", "--prompt-injection", "true"},
+			want: []string{"--", "--prompt-injection", "true"},
+		},
+		{
+			name: "trailing flag without value untouched",
+			in:   []string{"--prompt-injection"},
+			want: []string{"--prompt-injection"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeBoolFlagArgs(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("normalizeBoolFlagArgs() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("normalizeBoolFlagArgs() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZEGV7V90ECZZRY9JSV08MQX)

## Problem

The embedded detection prompt (`pkg/detector/prompts/threat_detection.md`) and the README document the result tool invocation as:

```
threat_detection_result --prompt-injection <true|false> --secret-leak <true|false> --malicious-patch <true|false> --reason "..."
```

But Go's `flag` package only accepts `--flag=value` for booleans. Given `--prompt-injection true`, `flag` sets the boolean to `true` and treats `true` as a **positional argument**, which terminates flag parsing entirely. Consequences of the documented invocation:

- `--secret-leak` and `--malicious-patch` were never parsed → `missing required flag --secret-leak` (exit 2)
- `--prompt-injection false` would have been recorded as `true` had parsing continued

So a model following the documented syntax could never record a verdict, burning a self-correction retry and potentially ending in an infrastructure error.

## Fix

`normalizeBoolFlagArgs` in `cmd/threat-detect/report.go` rewrites `--<bool-flag> <bool>` into `--<bool-flag>=<bool>` before `fs.Parse`. It:

- handles both `--flag` and `-flag` forms
- only applies to the three boolean flags (`prompt-injection`, `secret-leak`, `malicious-patch`)
- uses `strconv.ParseBool`, so non-boolean values are left untouched (and `--reason true` is unaffected)
- stops rewriting at the `--` terminator

Both the space-separated and `=` forms now work, so the documented syntax is valid and no prompt changes are needed.

## Tests

- `TestRunReportSpaceSeparatedBooleans` — end-to-end sink write via the documented syntax
- `TestRunReportSpaceSeparatedSingleDash` — single-dash form
- `TestNormalizeBoolFlagArgs` — table-driven: joining, `=` form passthrough, `--reason true`, non-boolean values, `--` terminator, trailing flag

`make fmt lint build test` all pass, plus a manual end-to-end CLI run confirming the correct JSON verdict is written to the sink.

Also added a one-line README note that both flag forms are accepted.

No change to the JSON result contract.