### PR TITLE
fix(detector): bound and sanitize the open-text reasons in detection_result.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,16 @@ explicitly treated as untrusted runtime data.
 }
 ```
 
+The three booleans are fully constrained by the schema: all are required, no
+other fields are accepted, and a result that adds, omits, or mistypes a field is
+rejected. `reasons` is model-authored free text and is bounded as well — at most
+20 entries, each non-blank and at most 1000 characters — and the whole result
+file is capped at 1 MiB before it is parsed. The same bounds apply when the model
+reports a result and when the file is read back, so a recorded result can never
+fail validation later. A rejected report is returned to the model as a
+correctable tool error; an oversized or malformed result file is a parse error
+that fails the detection closed.
+
 ### Replay workflow
 
 Maintainers can manually run **Replay Threat Detection** from the Actions tab to rerun detection against artifacts from a prior workflow run. Provide the source repository and run ID; the workflow downloads the `agent`, `activation`, optional experiment, and optional original `detection` artifacts, normalizes them into the CLI input contract above, runs `threat-detect`, and uploads a sanitized `replay-detection-<run_id>` artifact with the manifest, file inventory, free-form replay log, replay result, and original-result comparison. Detectors that support structured logging also produce `detection-runlog.jsonl`; when available, the source run's structured log is retained separately as `original-detection-runlog.jsonl`.

--- a/cmd/threat-detect/conclude.go
+++ b/cmd/threat-detect/conclude.go
@@ -295,7 +295,14 @@ func (c *concluder) conclude(resultFile string) int {
 		}
 		message := fmt.Sprintf("%s: ❌ Security threats detected: %s", errCodeValidation, strings.Join(threats, ", "))
 		if len(result.Reasons) > 0 {
-			message += "\nReasons: " + strings.Join(result.Reasons, "; ")
+			// Reasons are model-authored open text; sanitize and bound them the
+			// same way reportVerdict does before folding them into the workflow
+			// command and the run log.
+			safe := make([]string, 0, len(result.Reasons))
+			for _, reason := range result.Reasons {
+				safe = append(safe, sanitizeLogValue(truncateRunes(reason, maxEchoedLineRunes)))
+			}
+			message += "\nReasons: " + strings.Join(safe, "; ")
 		}
 		return c.fail(result, detector.ReasonThreatDetected, message)
 	}

--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/github/gh-aw-threat-detection/pkg/detector"
 )
 
 // parseKV reads a name=value file (as written to $GITHUB_OUTPUT / $GITHUB_ENV)
@@ -1086,5 +1088,72 @@ func TestConcludeToolingFailureLogsEngineFailure(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "This is a tooling failure, not a security finding.") {
 		t.Errorf("job log missing tooling-failure disclaimer; got:\n%s", stdout.String())
+	}
+}
+
+// TestConcludeThreatMessageSanitizesReasons verifies that model-authored reason
+// text cannot inject control characters into the ::error:: annotation. The
+// reasons list is open text, so it is escaped the same way reportVerdict
+// escapes it before being folded into the workflow command.
+func TestConcludeThreatMessageSanitizesReasons(t *testing.T) {
+	dir := t.TempDir()
+	resultFile := writeResultFixture(t,
+		`{"prompt_injection":true,"secret_leak":false,"malicious_patch":false,"reasons":["esc\u001b[31m tab\there"]}`)
+
+	var stdout bytes.Buffer
+	c := &concluder{
+		runDetection: "true",
+		githubOutput: filepath.Join(dir, "out"),
+		githubEnv:    filepath.Join(dir, "env"),
+		stdout:       &stdout,
+	}
+	if code := c.run(resultFile); code != concludeExitFail {
+		t.Fatalf("exit code = %d, want %d", code, concludeExitFail)
+	}
+	errorLine := ""
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if strings.HasPrefix(line, "::error::") {
+			errorLine = line
+		}
+	}
+	if errorLine == "" {
+		t.Fatalf("expected ::error:: command, got: %q", stdout.String())
+	}
+	if strings.ContainsAny(errorLine, "\x1b\t") {
+		t.Fatalf("control characters must be escaped in the annotation, got: %q", errorLine)
+	}
+	if !strings.Contains(errorLine, `esc\x1b[31m tab\there`) {
+		t.Fatalf("expected escaped reason text, got: %q", errorLine)
+	}
+}
+
+// TestConcludeRejectsOversizeResultFile verifies that an oversized result file
+// is reported as a parse error and fails closed, instead of being read into
+// memory and echoed in full into the job log.
+func TestConcludeRejectsOversizeResultFile(t *testing.T) {
+	dir := t.TempDir()
+	resultFile := writeResultFixture(t,
+		`{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":["`+
+			strings.Repeat("x", detector.MaxResultFileBytes)+`"]}`)
+
+	var stdout bytes.Buffer
+	c := &concluder{
+		runDetection: "true",
+		githubOutput: filepath.Join(dir, "out"),
+		githubEnv:    filepath.Join(dir, "env"),
+		stdout:       &stdout,
+	}
+	if code := c.run(resultFile); code != concludeExitFail {
+		t.Fatalf("exit code = %d, want %d", code, concludeExitFail)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, errCodeParse) {
+		t.Fatalf("expected %s, got: %q", errCodeParse, got)
+	}
+	if len(got) > 1<<16 {
+		t.Fatalf("oversize result file must not be echoed into the job log; got %d bytes", len(got))
+	}
+	if outputs := parseKV(t, filepath.Join(dir, "out")); outputs["reason"] != detector.ReasonParseError {
+		t.Fatalf("reason = %q, want %q", outputs["reason"], detector.ReasonParseError)
 	}
 }

--- a/pkg/detector/prompts/threat_detection.md
+++ b/pkg/detector/prompts/threat_detection.md
@@ -180,7 +180,9 @@ Analyze the above content for the following security threats, using the workflow
 
 Pass each `--prompt-injection`, `--secret-leak`, and `--malicious-patch` flag as `true` if you detect that
 type of threat, `false` otherwise. Add one `--reason` flag per detected threat explaining it (at least one
-`--reason` is required whenever any threat is `true`).
+`--reason` is required whenever any threat is `true`). Each `--reason` must be non-empty and at most 1000
+characters, and you may pass at most 20 of them — write concise explanations, not transcripts or quoted
+artifact dumps.
 
 The command validates your input and prints `THREAT_DETECTION_RESULT_ERROR` with the problem if anything is
 wrong — fix it and run the command again. When it prints `THREAT_DETECTION_RESULT_RECORDED`, the analysis is

--- a/pkg/detector/result.go
+++ b/pkg/detector/result.go
@@ -7,6 +7,25 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+// Bounds on the free-text portion of the result contract. The three boolean
+// fields are fully constrained by their type, but `reasons` is model-authored
+// open text that flows into job logs, workflow commands, and the run log, so it
+// is bounded on both the reporting and the reading side.
+const (
+	// MaxReasons is the maximum number of entries allowed in `reasons`. Three
+	// threat categories never need more than a handful of explanations.
+	MaxReasons = 20
+	// MaxReasonRunes is the maximum length of a single reason. Reasons are
+	// human-readable explanations, not transcripts or embedded artifacts.
+	MaxReasonRunes = 1000
+	// MaxResultFileBytes caps how much of a result file is read before parsing.
+	// It is far above any schema-valid result (MaxReasons × MaxReasonRunes plus
+	// JSON overhead) yet bounds memory for a corrupt or hostile file.
+	MaxResultFileBytes = 1 << 20 // 1 MiB
 )
 
 // Result represents the structured output of threat detection analysis.
@@ -82,9 +101,19 @@ func validateRawResult(raw map[string]any, label string) error {
 	if !ok {
 		return fmt.Errorf("invalid type for %q: expected array, got %T (%v)", "reasons", reasons, reasons)
 	}
+	if len(reasonsArr) > MaxReasons {
+		return fmt.Errorf("too many entries in %q: got %d, maximum is %d", "reasons", len(reasonsArr), MaxReasons)
+	}
 	for i, reason := range reasonsArr {
-		if _, ok := reason.(string); !ok {
+		text, ok := reason.(string)
+		if !ok {
 			return fmt.Errorf("invalid type for %q[%d]: expected string, got %T (%v)", "reasons", i, reason, reason)
+		}
+		if strings.TrimSpace(text) == "" {
+			return fmt.Errorf("invalid value for %q[%d]: reason must not be empty or whitespace-only", "reasons", i)
+		}
+		if n := utf8.RuneCountInString(text); n > MaxReasonRunes {
+			return fmt.Errorf("invalid value for %q[%d]: reason is %d characters, maximum is %d", "reasons", i, n, MaxReasonRunes)
 		}
 	}
 	return nil
@@ -133,11 +162,22 @@ func WriteResultFile(path string, r *Result) error {
 }
 
 // ReadResultFile reads path and parses it with ParseStructuredResult, returning
-// a validated *Result. Returns an error if the file is missing, empty, or invalid.
+// a validated *Result. Returns an error if the file is missing, empty, larger
+// than MaxResultFileBytes, or invalid.
 func ReadResultFile(path string) (*Result, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
+	}
+	defer f.Close()
+	// Read one byte past the cap so an oversized file is rejected rather than
+	// silently truncated into a parse error that hides the real cause.
+	data, err := io.ReadAll(io.LimitReader(f, MaxResultFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > MaxResultFileBytes {
+		return nil, fmt.Errorf("result file %q exceeds the maximum size of %d bytes", path, MaxResultFileBytes)
 	}
 	if len(bytes.TrimSpace(data)) == 0 {
 		return nil, fmt.Errorf("result file %q is empty", path)

--- a/pkg/detector/result.go
+++ b/pkg/detector/result.go
@@ -121,6 +121,13 @@ func validateRawResult(raw map[string]any, label string) error {
 
 // WriteResultFile atomically writes r as canonical THREAT_DETECTION_RESULT JSON
 // to path (temp file in the same dir + rename), with 0o600 permissions.
+//
+// The marshaled bytes are validated against the same rules ReadResultFile
+// applies before any file is created, so a result that would not survive being
+// read back is rejected at the source rather than persisted as an unreadable
+// file. Validating the canonical JSON — rather than the in-memory struct —
+// makes the guarantee exact: what is checked is byte-for-byte what a reader
+// would parse.
 func WriteResultFile(path string, r *Result) error {
 	if r == nil {
 		return fmt.Errorf("cannot write nil result")
@@ -133,6 +140,12 @@ func WriteResultFile(path string, r *Result) error {
 	data, err := json.MarshalIndent(&out, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling result: %w", err)
+	}
+	if int64(len(data)) > MaxResultFileBytes {
+		return fmt.Errorf("refusing to write result: encoded result is %d bytes, exceeding the maximum of %d", len(data), MaxResultFileBytes)
+	}
+	if _, err := ParseStructuredResult(data); err != nil {
+		return fmt.Errorf("refusing to write result that could not be read back: %w", err)
 	}
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".threat-detect-result-*.tmp")

--- a/pkg/detector/result_test.go
+++ b/pkg/detector/result_test.go
@@ -1,6 +1,9 @@
 package detector
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -40,5 +43,92 @@ func TestResult_HasThreats(t *testing.T) {
 				t.Errorf("HasThreats() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseStructuredResult_ReasonBounds(t *testing.T) {
+	build := func(reasons string) []byte {
+		return []byte(`{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[` + reasons + `]}`)
+	}
+
+	tests := []struct {
+		name    string
+		reasons string
+		wantErr bool
+	}{
+		{"single reason", `"looks fine"`, false},
+		{"max length reason", `"` + strings.Repeat("x", MaxReasonRunes) + `"`, false},
+		{"max count reasons", strings.TrimSuffix(strings.Repeat(`"r",`, MaxReasons), ","), false},
+		{"empty reason", `""`, true},
+		{"whitespace-only reason", `" \t "`, true},
+		{"over-long reason", `"` + strings.Repeat("x", MaxReasonRunes+1) + `"`, true},
+		{"too many reasons", strings.TrimSuffix(strings.Repeat(`"r",`, MaxReasons+1), ","), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseStructuredResult(build(tt.reasons))
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error for %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestParseStructuredResult_ReasonRunesCountedAsRunes(t *testing.T) {
+	// MaxReasonRunes bounds characters, not bytes: a multi-byte reason at the
+	// limit must be accepted even though its byte length exceeds the limit.
+	data := []byte(`{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":["` +
+		strings.Repeat("é", MaxReasonRunes) + `"]}`)
+	if _, err := ParseStructuredResult(data); err != nil {
+		t.Fatalf("unexpected error for multi-byte reason at the rune limit: %v", err)
+	}
+}
+
+func TestReadResultFile_RejectsOversizeFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "detection_result.json")
+	// A syntactically valid but oversized file must be rejected on size before
+	// it is parsed, so a hostile file cannot be read into memory in full.
+	payload := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":["` +
+		strings.Repeat("x", MaxResultFileBytes) + `"]}`
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("writing oversize result file: %v", err)
+	}
+	_, err := ReadResultFile(path)
+	if err == nil {
+		t.Fatal("expected oversize result file to be rejected")
+	}
+	if !strings.Contains(err.Error(), "exceeds the maximum size") {
+		t.Fatalf("expected size error, got: %v", err)
+	}
+}
+
+func TestReadResultFile_RoundTripsWrittenResult(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "detection_result.json")
+	// Every result the detector writes must pass its own read-side validation.
+	want := BuildResultFromReport(true, false, false, []string{"injected instruction in issue body"})
+	if err := WriteResultFile(path, want); err != nil {
+		t.Fatalf("writing result: %v", err)
+	}
+	got, err := ReadResultFile(path)
+	if err != nil {
+		t.Fatalf("reading back written result: %v", err)
+	}
+	if !got.HasThreats() || len(got.Reasons) != 1 || got.Reasons[0] != want.Reasons[0] {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestValidateReportFields_BoundsReasons(t *testing.T) {
+	if msg := ValidateReportFields(false, false, false, []any{"  "}); msg == "" {
+		t.Fatal("expected whitespace-only reason to be rejected at report time")
+	}
+	if msg := ValidateReportFields(true, false, false, []any{"real reason"}); msg != "" {
+		t.Fatalf("unexpected rejection: %s", msg)
 	}
 }

--- a/pkg/detector/result_test.go
+++ b/pkg/detector/result_test.go
@@ -132,3 +132,61 @@ func TestValidateReportFields_BoundsReasons(t *testing.T) {
 		t.Fatalf("unexpected rejection: %s", msg)
 	}
 }
+
+// TestWriteResultFile_RejectsUnreadableResult verifies the write/read symmetry
+// required by TD-10b: a result that would be rejected on read must be rejected
+// on write, and must not leave a file behind. Without this, a caller that
+// bypassed the report-time validation could persist a result file that only
+// fails much later, at conclude time, as a misleading parse error.
+func TestWriteResultFile_RejectsUnreadableResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *Result
+	}{
+		{"over-long reason", &Result{PromptInjection: true, Reasons: []string{strings.Repeat("x", MaxReasonRunes+1)}}},
+		{"blank reason", &Result{PromptInjection: true, Reasons: []string{"   "}}},
+		{"empty reason", &Result{PromptInjection: true, Reasons: []string{""}}},
+		{"too many reasons", &Result{PromptInjection: true, Reasons: make([]string, MaxReasons+1)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "detection_result.json")
+			if err := WriteResultFile(path, tt.result); err == nil {
+				t.Fatal("expected write to be rejected")
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("rejected write must not leave a result file behind (stat err = %v)", err)
+			}
+			// The atomic-write temp file must be cleaned up too.
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("ReadDir error = %v", err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("rejected write left %d file(s) behind: %v", len(entries), entries)
+			}
+		})
+	}
+}
+
+// TestWriteResultFile_AcceptsBoundaryResult verifies the symmetry does not
+// over-reject: a result exactly at the documented limits must round-trip.
+func TestWriteResultFile_AcceptsBoundaryResult(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "detection_result.json")
+	reasons := make([]string, MaxReasons)
+	for i := range reasons {
+		reasons[i] = strings.Repeat("y", MaxReasonRunes)
+	}
+	if err := WriteResultFile(path, &Result{SecretLeak: true, Reasons: reasons}); err != nil {
+		t.Fatalf("result at the documented limits must be writable: %v", err)
+	}
+	got, err := ReadResultFile(path)
+	if err != nil {
+		t.Fatalf("result at the documented limits must be readable: %v", err)
+	}
+	if len(got.Reasons) != MaxReasons {
+		t.Fatalf("reasons = %d, want %d", len(got.Reasons), MaxReasons)
+	}
+}

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -96,6 +96,20 @@ use the same JSON object shape as TD-08 with required boolean `prompt_injection`
 field. The implementation MUST reject results that add unexpected fields, omit a
 required field, or use the wrong type for any field.
 
+**TD-10b**: The `reasons` array is model-authored free text and MUST be bounded.
+The implementation MUST reject a result whose `reasons` array contains more than
+20 entries, or whose individual entry is empty, consists solely of whitespace, or
+exceeds 1000 characters. These bounds MUST be enforced identically when a result
+is reported through the `threat_detection_result` tool and when a result file is
+read back, so no result the implementation accepts on write can be rejected on
+read. A rejected report MUST be reported to the model as a correctable error
+(TD-10a) rather than recorded.
+
+**TD-10c**: The implementation MUST bound the number of bytes it reads from a
+result file before parsing it, and MUST reject a file that exceeds that bound as
+a parse error rather than parsing a truncated prefix. The bound MUST be large
+enough to admit every result permitted by TD-10a and TD-10b.
+
 
 ---
 


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZEMFVH8FWG47H8HRXP1PM06)

## Summary

The three boolean fields of the result contract were already strictly validated — required, correctly typed, no extra fields, no trailing JSON — and the same validator runs on both the `threat_detection_result` tool path and the file-read path.

The `reasons` array had no validation beyond "every element is a string". It is model-authored free text that flows into job logs, workflow command annotations, and the run log. This PR bounds it.

## Defects fixed

All three were reproduced against `bin/threat-detect` before fixing.

**1. Unbounded size.** A `detection_result.json` with 500 reasons of 200 KB each (100 MB) was accepted on both the report and the read side. `conclude` read it fully into memory and emitted **200 MB into the job log**. Now rejected as `ERR_PARSE` with 1.8 KB of output.

**2. Blank reasons accepted.** `--reason "   "` passed validation, silently defeating the existing "at least one reason when any threat is true" rule — a threat could be reported with no usable explanation.

**3. Unsanitized in the error annotation.** The `fail` path joined reasons raw. `escapeWorkflowData` neutralized `\r\n`, so there was no workflow-command injection, but ANSI and other control characters reached the job log unescaped — inconsistent with `reportVerdict`, which already escaped them via `sanitizeLogValue`.

## Changes

Bounds are enforced symmetrically on write and read, so no result the tool accepts can be rejected later:

- at most 20 reasons, each non-blank and at most 1000 runes (counted as runes, not bytes)
- result-file reads capped at 1 MiB, with oversized files rejected as parse errors rather than parsed as a truncated prefix
- reasons sanitized and truncated before being folded into the `::error::` annotation

A rejected report reaches the model as a correctable tool error, so it retries rather than failing the run. An oversized or malformed result file is a parse error that fails detection closed.

Bounds are documented as TD-10b/TD-10c in the spec, in the README, and in the detection prompt so the model targets the limits rather than discovering them by retry.

## Design note

Over-long reasons are **rejected** rather than truncated. Truncating would silently alter a security verdict's justification; rejecting gives the model a bounded, actionable retry. If failing a run on a verbose reason is not acceptable, truncation-with-marker is the alternative.

## Testing

12 new test cases covering each bound, rune-vs-byte counting, write/read round-tripping, oversize-file rejection, and control-character escaping in the annotation.

`make fmt-check`, `make lint`, `make build`, and `make test` (race) all pass. `make security-scan` reports an identical 37 gosec findings before and after this change — a pre-existing local-toolchain issue (`gosec dev` vs the pinned v2.23.0), not introduced here.

## Scope

This is the validation/robustness fix only. The separate discussion about keeping model-authored reason text out of the uploaded artifact (routing it to the masked job log and leaving a reference in the JSON) is not addressed here and needs its own change.