### PR TITLE
fix(cli): accept and ignore deprecated --step-summary flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ threat-detect [flags] <artifacts-dir>
 - `--custom-prompt-file` — Path to a file with additional detection instructions. Takes precedence over `--custom-prompt` and `CUSTOM_PROMPT`
 - `--output` — Path to write JSON result (defaults to stdout)
 - `--retries` — Retries for malformed detection outputs. Default: `1` (env: `THREAT_DETECTION_RETRIES`)
+- `--step-summary` — Deprecated and ignored. Accepted so hosts that still pass it (older `gh-aw` releases) do not fail; the detector no longer writes a GitHub Actions step summary
 - `--version` — Print version and exit
 
 `threat-detect` runs a single agentic CLI engine pass. The engine reports its

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -115,6 +115,7 @@ func run() (code int) {
 		workflowDescription string
 		customPrompt        string
 		customPromptFile    string
+		stepSummary         string
 		version             bool
 		retries             int
 	)
@@ -132,6 +133,11 @@ func run() (code int) {
 	flag.StringVar(&workflowDescription, "workflow-description", "", "Workflow description for the prompt (overrides WORKFLOW_DESCRIPTION)")
 	flag.StringVar(&customPrompt, "custom-prompt", "", "Additional detection instructions appended to the prompt (overrides CUSTOM_PROMPT)")
 	flag.StringVar(&customPromptFile, "custom-prompt-file", "", "Path to a file with additional detection instructions (takes precedence over --custom-prompt and CUSTOM_PROMPT)")
+	// Accepted and ignored for backward compatibility: older gh-aw releases pass
+	// --step-summary, but the detector no longer writes a step summary (TD-20c).
+	// Rejecting the flag would abort detection in those hosts, so it is parsed
+	// and dropped instead.
+	flag.StringVar(&stepSummary, "step-summary", "", "Deprecated and ignored; the detector no longer writes a GitHub Actions step summary")
 	flag.BoolVar(&version, "version", false, "Print version and exit")
 	flag.IntVar(&retries, "retries", envInt("THREAT_DETECTION_RETRIES", 1), "Retries for malformed detection outputs (env: THREAT_DETECTION_RETRIES)")
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
@@ -146,6 +152,17 @@ func run() (code int) {
 	if version {
 		fmt.Printf("threat-detect %s\n", detector.Version)
 		return exitSafe
+	}
+
+	stepSummaryProvided := false
+	flag.CommandLine.Visit(func(f *flag.Flag) {
+		if f.Name == "step-summary" {
+			stepSummaryProvided = true
+		}
+	})
+	if stepSummaryProvided {
+		fmt.Fprintf(os.Stderr, "[threat-detect] ignoring deprecated --step-summary %s: the detector no longer writes a step summary\n",
+			sanitizeLogValue(stepSummary))
 	}
 
 	// When --model is not set, fall back to the engine-specific detection model

--- a/cmd/threat-detect/main_test.go
+++ b/cmd/threat-detect/main_test.go
@@ -827,3 +827,44 @@ func TestRunStartLineEscapesEngineID(t *testing.T) {
 		}
 	}
 }
+
+// TestRunAcceptsAndIgnoresStepSummaryFlag verifies the removed --step-summary
+// option is still parsed and dropped (TD-20c) so hosts that still pass it do not
+// abort detection with a flag error.
+func TestRunAcceptsAndIgnoresStepSummaryFlag(t *testing.T) {
+	artifactsDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(artifactsDir, "aw-prompts"), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactsDir, "aw-prompts", "prompt.txt"), []byte("analyze this"), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactsDir, "agent_output.json"), []byte(`{"items":[]}`), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "result.json")
+	summaryPath := filepath.Join(t.TempDir(), "step-summary.md")
+	copilotMarker := filepath.Join(t.TempDir(), "copilot-called")
+	sinkJSON := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	fakeBinDir := writeFakeCopilotWithSink(t, copilotMarker, sinkJSON, 0)
+
+	code, stderr := runWithTestArgsCapture(t, []string{
+		"threat-detect",
+		"-output", outputPath,
+		"-step-summary", summaryPath,
+		artifactsDir,
+	}, map[string]string{
+		"PATH": fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	})
+
+	if code != exitSafe {
+		t.Fatalf("run() exit code = %d, want %d; stderr:\n%s", code, exitSafe, stderr)
+	}
+	if !strings.Contains(stderr, "ignoring deprecated --step-summary") {
+		t.Errorf("stderr missing the ignored --step-summary notice, got:\n%s", stderr)
+	}
+	if _, err := os.Stat(summaryPath); !os.IsNotExist(err) {
+		t.Errorf("expected no step summary to be written to %s, stat err = %v", summaryPath, err)
+	}
+}

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -288,7 +288,10 @@ artifact inventory defined by TD-17b is surfaced on standard error (TD-20a) only
 and the conclusion verdict through the `conclude` diagnostics (TD-20d). The
 rendered prompt itself MUST NOT be surfaced: the detector reports only its
 metadata (byte count, resolved workflow name/description, custom-prompt
-provenance, scaffolding detection).
+provenance, scaffolding detection). For compatibility with hosts that still pass
+the removed `--step-summary <path>` option, the detector MUST accept that option,
+ignore its value, note on standard error that it was ignored, and MUST NOT treat
+it as a configuration error.
 
 **TD-20d**: The `conclude` subcommand MUST write a human-readable diagnostic
 section to standard output that is sufficient, on its own, to explain the

--- a/specs/usage-spec.md
+++ b/specs/usage-spec.md
@@ -170,6 +170,7 @@ versions.
 | `--prompt-template <path>` | Override the embedded default prompt |
 | `--output <path>` | Write the JSON result to a file instead of stdout |
 | `--retries <n>` | Retries for malformed detection outputs (default `1`) |
+| `--step-summary <path>` | Deprecated and ignored; accepted only for compatibility with hosts that still pass it (per TD-20c) |
 | `--version` | Print version and exit |
 
 ---


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZF9YQ1GBCQ3TV7MM2AXJD1M)

## Problem

Smoke tests fail because `gh-aw`-compiled workflows still pass `--step-summary /tmp/gh-aw/step-summary.md` to `threat-detect`, but the step-summary output was removed from the detector. Go's flag parser aborts the run:

```
flag provided but not defined: -step-summary
Usage of threat-detect:
...
```

This turns into a detection infrastructure error (exit 2) before the engine ever runs.

## Fix

Make `--step-summary <path>` a real, documented flag that is parsed and explicitly dropped:

- `cmd/threat-detect/main.go` — registers the flag. When explicitly provided, the detector logs `[threat-detect] ignoring deprecated --step-summary <path>: the detector no longer writes a step summary` (value sanitized like other logged values) and proceeds normally. Nothing is written to the path.
- `README.md` — flag listed as deprecated/ignored.
- `specs/threat-detection-spec.md` (TD-20c) — the detector MUST accept the option, ignore its value, note it on stderr, and MUST NOT treat it as a configuration error.
- `specs/usage-spec.md` (U-10 flag table) — same, cross-referenced to TD-20c.

## Testing

- New `TestRunAcceptsAndIgnoresStepSummaryFlag`: exit 0, notice on stderr, no summary file created.
- `make fmt lint build test` all pass.
- Manually verified against the built binary.