### PR TITLE
fix(smoke): replace unsatisfiable web-fetch check with curl egress check

### DIFF
--- a/.github/workflows/smoke-codex-standalone.md
+++ b/.github/workflows/smoke-codex-standalone.md
@@ -68,7 +68,7 @@ requirement — do not keep waiting.
 ## Test Requirements
 
 1. Use GitHub tools to read the latest 2 pull requests in `${{ github.repository }}` and record their numbers and titles only.
-2. Use bash to run `curl -sSL https://github.com/github/gh-aw-threat-detection` and verify the response mentions `gh-aw-threat-detection`. This is an egress check through the AWF firewall: the Codex CLI has no web-fetch tool, so do **not** try to satisfy this with `web-fetch`.
+2. Use bash to run `curl -fsSL https://github.com/github/gh-aw-threat-detection` and verify the command exits `0` **and** its output mentions `gh-aw-threat-detection`. The `-f` flag is required so an HTTP 4xx/5xx response (for example an AWF/Squid denial page, which may itself echo the requested URL) fails instead of counting as a successful fetch. This is an egress check through the AWF firewall: the Codex CLI has no web-fetch tool, so do **not** try to satisfy this with `web-fetch`.
 3. Use bash to run `make lint` and `make build` in `${{ github.workspace }}` and verify both succeed.
 4. Use bash to create a minimal artifacts directory under `/tmp/gh-aw/smoke-codex-standalone-${{ github.run_id }}` with:
    - `aw-prompts/prompt.txt`

--- a/.github/workflows/smoke-codex-standalone.md
+++ b/.github/workflows/smoke-codex-standalone.md
@@ -68,7 +68,7 @@ requirement — do not keep waiting.
 ## Test Requirements
 
 1. Use GitHub tools to read the latest 2 pull requests in `${{ github.repository }}` and record their numbers and titles only.
-2. Use `web-fetch` to fetch `https://github.com/github/gh-aw-threat-detection` and verify the response mentions `gh-aw-threat-detection`.
+2. Use bash to run `curl -sSL https://github.com/github/gh-aw-threat-detection` and verify the response mentions `gh-aw-threat-detection`. This is an egress check through the AWF firewall: the Codex CLI has no web-fetch tool, so do **not** try to satisfy this with `web-fetch`.
 3. Use bash to run `make lint` and `make build` in `${{ github.workspace }}` and verify both succeed.
 4. Use bash to create a minimal artifacts directory under `/tmp/gh-aw/smoke-codex-standalone-${{ github.run_id }}` with:
    - `aw-prompts/prompt.txt`


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZVJ2CAJNT1CAAY6Q6MC4W3Y)

Closes #828

## Problem

Test 2 of the Codex standalone smoke fails every day (see #828):

> ❌ Test 2: web-fetch `https://github.com/github/gh-aw-threat-detection` and verify `gh-aw-threat-detection` is mentioned. Result: `web-fetch` tool unavailable in this session.

## Root cause

**The Codex CLI has no web-fetch tool.** `openai/codex` implements `web_search` (`web_search_mode`, `WebSearchConfig`) but nothing for fetching a URL, so gh-aw's `-c fetch="disabled"` toggle is effectively a no-op config key.

This is *not* a missing declaration or a stale lock:

- `web-fetch:` is already in the frontmatter.
- The compiled lock is correct — gh-aw omits `-c fetch="disabled"` from `codex exec`, which is exactly what enabling `web-fetch` means for Codex.

The agent log from run 31610933363 confirms it reached the same conclusion:

```
"`web-fetch` is not exposed in this session. I'm proceeding with the rest
 of the smoke checks and I'll mark that requirement failed"
```

The Copilot smoke passes the equivalent check because the Copilot CLI has a built-in fetch tool. Codex does not, so this requirement was unsatisfiable as written.

## Change

Requirement 2 now does a `curl` egress check instead. This is deterministic, still exercises HTTPS egress through the AWF firewall, and needs no frontmatter changes — `bash: ["*"]` and `network: allowed: [defaults, github]` already cover it.

`web-fetch:` is intentionally left in the frontmatter: it's what keeps gh-aw from emitting `-c fetch="disabled"`, so the check starts working for free if Codex ever ships a fetch tool.

## Follow-up required

⚠️ **The `.lock.yml` still needs recompiling** — this PR only touches the `.md`. Only the body changed, so just `body_hash` moves; the frontmatter is untouched. Recompile with `gh aw` **v0.86.1** to match the existing lock's `compiler_version`.