### PR TITLE
fix(logs): close legacy workflow-command gaps and stop truncating reasons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ threat-detect [flags] <artifacts-dir>
 
 The detector reads the verdict exclusively from the out-of-band result sink. The engine reports its verdict in-session by invoking the `threat_detection_result` tool, which writes the JSON object (`prompt_injection`, `secret_leak`, `malicious_patch`, `reasons`) to the sink (`detector.ReadResultFile` / `detector.ParseStructuredResult`).
 
-**The verdict is split on write (TD-10d).** `--output` always carries `reasons: []`; the reported reasons go only to `--full-output` (`detection_result_full.json`), which stays on the runner and MUST NOT be uploaded. The schema is unchanged — `reasons` stays a required array, just empty — so parsers, validation bounds, and replay comparisons are unaffected. `conclude` reads the full result via `--full-result-file` (derived from `--result-file` by default) and renders the reasons into the masked job log; it never lets that file move or contradict the verdict. No detector-authored diagnostic echoes the reasons, because hosts tee stdout/stderr into published files; forwarded engine output (`[engine] `-prefixed, framed by #851) is out of scope and does reproduce them, so a captured stderr file must not be uploaded.
+**The verdict is split on write (TD-10f).** `--output` always carries `reasons: []`; the reported reasons go only to `--full-output` (`detection_result_full.json`), which stays on the runner and MUST NOT be uploaded. The schema is unchanged — `reasons` stays a required array, just empty — so parsers, validation bounds, and replay comparisons are unaffected. `conclude` reads the full result via `--full-result-file` (derived from `--result-file` by default) and renders the reasons into the masked job log; it never lets that file move or contradict the verdict. No detector-authored diagnostic echoes the reasons, because hosts tee stdout/stderr into published files; forwarded engine output (`[engine] `-prefixed, framed by #851) is out of scope and does reproduce them, so a captured stderr file must not be uploaded.
 
 **Artifacts directory shape** (validated by `pkg/artifacts/artifacts.go`):
 
@@ -125,7 +125,7 @@ All files are recursively inventoried on stderr. The prompt consumes only an all
 - `pkg/detector/detector.go` (`BuildPrompt`) renders `prompts/threat_detection.md` with placeholders substituted from artifacts and `BuildPromptAnalysis` (untrusted-input breakdown).
 - The engine CLI is invoked from `PATH` via `pkg/engine/engine.go` (`copilot`, `claude`, and `codex` use engine-specific prompt-passing paths; `runCLIWithPromptFile` is used by Copilot).
 - The engine reports its verdict in-session by calling the `threat_detection_result` tool, which writes JSON to an out-of-band result sink (`pkg/engine/tool.go`); the sink is the sole source of the verdict, and the subprocess is cancelled as soon as a valid result is written.
-- If no sink result is written, a one-shot self-correction prompt is built (`pkg/detector/correction.go`) and retried (`--retries`, default 1); retry exhaustion is an infrastructure error. The engine transcript is never parsed for the result.
+- If no sink result is written, a self-correction prompt is built (`pkg/detector/correction.go`) and retried (`--retries`, default 1, so one correction attempt by default); retry exhaustion is an infrastructure error. The engine transcript is never parsed for the result.
 
 ## Release & Promotion Model
 
@@ -145,7 +145,7 @@ The `latest` (non-prerelease) GitHub release and "Latest" badge **only move on e
 
 This repo runs daily AW smoke tests against all three engines:
 
-- `.github/workflows/smoke-{copilot,claude,codex}-standalone.{md,lock.yml}` — `features: gh-aw-detection: true`, so gh-aw natively downloads this repo's released `threat-detect` binary, runs it under AWF, and concludes from the structured `detection_result.json` via `threat-detect conclude`. The `.lock.yml` files are compiled by `gh aw compile`.
+- `.github/workflows/smoke-{copilot,claude,codex}-standalone.{md,lock.yml}` — `features: gh-aw-detection: true`, so gh-aw natively downloads this repo's released `threat-detect` binary, runs it under AWF, and concludes from the structured `detection_result.json`. The `.lock.yml` files are compiled by `gh aw compile`. Note the locks conclude with gh-aw's `conclude_threat_detection.sh`, **not** `threat-detect conclude`, so they never perform the `--full-result-file` lookup and their job logs show no reasons; use `replay-detection.yml` when you need the reasons.
 
 The detector version is **not** pinned in the locks: gh-aw emits the literal `latest`, which `install_threat_detect_binary.sh` resolves at run time to the newest **non-prerelease** detector release. Promoting a release is enough to put it in front of the smokes — no recompile. Unpromoted prereleases are never picked up automatically; test those via `replay-detection.yml` with `detector_source=release` and `detector_ref=<prerelease tag>`.
 
@@ -165,7 +165,7 @@ When changing this repo:
 
 - **Spec first**: behavior changes must align with [`specs/threat-detection-spec.md`](specs/threat-detection-spec.md). Update the spec when the contract changes.
 - **Preserve the JSON result contract**: `prompt_injection`, `secret_leak`, `malicious_patch`, `reasons` — schema enforced by the parser in `pkg/detector/result.go`.
-- **Never persist reasons in a published file**: model-authored text belongs in the full result and the job log only (TD-10d, TD-20e, U-08a).
+- **Never persist reasons in a published file**: model-authored text belongs in the full result and the job log only (TD-10f, TD-20e, U-08a).
 - **Don't bundle engine CLIs into the binary**. Engines (Copilot, Claude, Codex) are invoked from `PATH`. The runner provides the engine.
 - **No new JS scripts**. Detection setup and result parsing are Go. Old gh-aw JS detection scripts are being retired.
 - **Custom orchestrator steps** (`threat-detection.steps`) belong in the `gh-aw` job, not inside the detector.

--- a/README.md
+++ b/README.md
@@ -148,11 +148,15 @@ line. The rendered prompt itself is never echoed.
 Untrusted values interpolated into these detector-authored lines are escaped so
 that each stays on lines of its own and listings are bounded, so neither a
 model-authored string nor a hostile filename can forge a workflow command or
-flood the job log. That covers **both** marker forms the Actions runner accepts:
-the `::command::` form, which it honors only at the start of a line, and the
-legacy `##[command]` form, which it locates anywhere within a line — including
-inside the data of an annotation the detector itself emits — and which is
-therefore broken up inside the value (`##[` is rendered `##\[`). The
+flood the job log. Escaping happens on the way out — every detector diagnostic
+goes through one writer, and so does every `conclude` line — rather than at each
+call site, so a new diagnostic cannot reintroduce the gap. It covers **both**
+marker forms the Actions runner accepts: the `::command::` form, which it honors
+only at the start of a line, and the legacy `##[command]` form, which it locates
+anywhere within a line and which is therefore broken up inside the value (`##[`
+is rendered `##\[`). Annotation data is neutralized the same way; the runner
+does not rescan the data of a command it already recognized, so that part is
+defense in depth. The
 engine subprocess's own stdout/stderr are a separate, untrusted stream: they are
 forwarded line by line in real time (so harness output and engine errors stay
 visible), each line prefixed with `[engine] ` and stripped of its ability to open

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ verdict in-session by invoking the `threat_detection_result` tool, which writes
 a strict JSON object matching the result contract to an out-of-band result sink;
 the detector cancels the engine subprocess as soon as a valid result is written.
 The verdict is read exclusively from that sink; if no sink result is produced, a
-one-shot self-correction prompt is retried, and retry exhaustion is treated as an
-infrastructure error.
+self-correction prompt is retried (`--retries`, once by default), and retry
+exhaustion is treated as an infrastructure error.
 
 #### In-session result reporting (`threat_detection_result`)
 
@@ -145,14 +145,20 @@ it recorded a verdict, the engine subprocess invocation and argv, any
 `::warning::`/`::error::` annotations for degraded inputs, and the terminal status
 line. The rendered prompt itself is never echoed.
 
-Untrusted values interpolated into these detector-authored lines are escaped to a
-single physical line and listings are bounded, so neither a model-authored string
-nor a hostile filename can forge a workflow command or flood the job log. The
+Untrusted values interpolated into these detector-authored lines are escaped so
+that each stays on lines of its own and listings are bounded, so neither a
+model-authored string nor a hostile filename can forge a workflow command or
+flood the job log. That covers **both** marker forms the Actions runner accepts:
+the `::command::` form, which it honors only at the start of a line, and the
+legacy `##[command]` form, which it locates anywhere within a line — including
+inside the data of an annotation the detector itself emits — and which is
+therefore broken up inside the value (`##[` is rendered `##\[`). The
 engine subprocess's own stdout/stderr are a separate, untrusted stream: they are
 forwarded line by line in real time (so harness output and engine errors stay
 visible), each line prefixed with `[engine] ` and stripped of its ability to open
-a workflow command. Forwarded lines are not detector-attested — log consumers
-must ignore any `THREAT_DETECTION_*` marker that carries the `[engine] ` prefix.
+a workflow command in either form. Forwarded lines are not detector-attested —
+log consumers must ignore any `THREAT_DETECTION_*` marker that carries the
+`[engine] ` prefix.
 
 ```text
 [threat-detect] run start: version=1.2.3 engine=copilot model=(none; using engine default) retries=1
@@ -215,6 +221,14 @@ from `--result-file` by the same convention the detection run uses (override wit
 verdict: a missing or unparseable full result is reported and ignored, a full
 result whose booleans disagree is discarded outright, and a pre-split result that
 still carries its own reasons renders them directly.
+
+Reasons are rendered into the verdict block with their line structure intact —
+each embedded newline becomes a real log line, prefixed with a gutter so no
+continuation line can begin a workflow command — and a line longer than the
+per-line bound is wrapped onto further lines rather than truncated, so the
+located, verbatim evidence a reason exists to carry survives the job log. The
+`::error::` annotation that follows is a summary and does bound each reason;
+it points back at the verdict block for the full text.
 
 `conclude` reproduces the `gh-aw` job-output contract — it writes `conclusion`,
 `reason`, and `success` to `GITHUB_OUTPUT` and exports `GH_AW_DETECTION_CONCLUSION`
@@ -489,7 +503,9 @@ This repository includes three Agentic Workflows smoke tests, one per engine:
 - `.github/workflows/smoke-claude-standalone.md`
 - `.github/workflows/smoke-codex-standalone.md`
 
-Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can be dispatched manually to start all three at once. The matching `.lock.yml` files are the compiled AW workflows. They set `features: gh-aw-detection: true`, so gh-aw natively downloads this repo's released binary matching the runner platform, runs it under AWF, and reads the structured `detection_result.json` via `threat-detect conclude`. The detector version they install is resolved at run time — see [Detector Version Selection](#detector-version-selection).
+Each runs daily and by `workflow_dispatch`. The top-level `Smoke` workflow can be dispatched manually to start all three at once. The matching `.lock.yml` files are the compiled AW workflows. They set `features: gh-aw-detection: true`, so gh-aw natively downloads this repo's released binary matching the runner platform, runs it under AWF, and reads the structured `detection_result.json` to conclude. The detector version they install is resolved at run time — see [Detector Version Selection](#detector-version-selection).
+
+**The smokes do not exercise `threat-detect conclude`.** The compiled locks conclude with gh-aw's own `conclude_threat_detection.sh`, which reads only `detection_result.json`. Because the published result deliberately carries `reasons: []`, the smokes' job logs show the verdict but no reasons: recovering those needs the `--full-result-file` lookup that only the `conclude` subcommand performs. Use [`replay-detection.yml`](#replay-workflow), which renders the reasons from the companion full result, when the explanations are what you need to see.
 
 **Codex detection model pin.** The Codex smokes pin the detection model explicitly:
 

--- a/cmd/threat-detect/conclude.go
+++ b/cmd/threat-detect/conclude.go
@@ -11,9 +11,11 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/github/gh-aw-threat-detection/pkg/detector"
 	"github.com/github/gh-aw-threat-detection/pkg/engine"
+	"github.com/github/gh-aw-threat-detection/pkg/logsafe"
 )
 
 // Exit codes for the conclude subcommand. These map directly onto whether the
@@ -387,27 +389,64 @@ func (c *concluder) reportVerdict(result *detector.Result, reasons []string) {
 // log lines to print. Reasons carry forensic detail — verbatim quotes of the
 // triggering content, file and line references — which is only usable if it
 // keeps its line structure, so embedded newlines become real lines rather than
-// escaped "\n" runs. Each returned line is individually sanitized (so no line
-// can carry a control character or start a line of its own) and bounded, and
-// the line count is capped so one pathological reason cannot flood the job log.
-// The result always has at least one element.
+// escaped "\n" runs.
+//
+// A source line longer than the per-line bound is wrapped across continuation
+// lines rather than truncated. Truncating would silently discard up to three
+// quarters of a reason written to the maximum MaxReasonRunes budget — precisely
+// the located, verbatim evidence the reason exists to carry — for a reason that
+// merely happens not to be pre-wrapped. The overall line count is still capped
+// so one pathological reason cannot flood the job log.
+//
+// Each returned line is individually sanitized, so no line can carry a control
+// character, start a line of its own, or embed a legacy workflow-command
+// marker. The result always has at least one element.
 func reasonLogLines(reason string) []string {
 	normalized := strings.ReplaceAll(reason, "\r\n", "\n")
 	normalized = strings.ReplaceAll(normalized, "\r", "\n")
-	raw := strings.Split(normalized, "\n")
+	lines := make([]string, 0, maxReasonLogLines+1)
 	truncated := false
-	if len(raw) > maxReasonLogLines {
-		raw = raw[:maxReasonLogLines]
-		truncated = true
+	for _, source := range strings.Split(normalized, "\n") {
+		for _, segment := range wrapRunes(source, maxEchoedLineRunes) {
+			if len(lines) == maxReasonLogLines {
+				truncated = true
+				break
+			}
+			lines = append(lines, sanitizeLogValue(segment))
+		}
+		if truncated {
+			break
+		}
 	}
-	lines := make([]string, 0, len(raw)+1)
-	for _, line := range raw {
-		lines = append(lines, sanitizeLogValue(truncateRunes(line, maxEchoedLineRunes)))
+	if len(lines) == 0 {
+		lines = append(lines, "")
 	}
 	if truncated {
 		lines = append(lines, "… (reason truncated)")
 	}
 	return lines
+}
+
+// wrapRunes splits s into segments of at most max runes, counting runes rather
+// than bytes so a multi-byte character is never split across segments. An empty
+// input yields a single empty segment, so a blank line inside a reason survives
+// as a blank line.
+func wrapRunes(s string, max int) []string {
+	if max <= 0 || utf8.RuneCountInString(s) <= max {
+		return []string{s}
+	}
+	var segments []string
+	count := 0
+	start := 0
+	for i := range s {
+		if count == max {
+			segments = append(segments, s[start:i])
+			start = i
+			count = 0
+		}
+		count++
+	}
+	return append(segments, s[start:])
 }
 
 // listDirectory prints a recursive listing of dir so a missing or unusable
@@ -556,21 +595,6 @@ func readBounded(path string, limit int64) ([]byte, int64, error) {
 	return data, totalBytes, nil
 }
 
-// legacyCommandMarker is the runner's legacy workflow-command marker,
-// "##[command]data". The Actions runner honors it in addition to the "::" form,
-// and — unlike "::", which it accepts only at the start of a line (after
-// trimming leading whitespace) — it locates this marker with an unanchored
-// IndexOf. A legacy marker anywhere inside a log line is therefore a live
-// command, so no line prefix, gutter, or indentation can render it inert: the
-// value itself must be broken up. Reachable commands include add-mask (which
-// redacts arbitrary text from the log) and stop-commands (which suppresses
-// every later command, including this program's own threat annotation).
-const legacyCommandMarker = "##["
-
-// legacyCommandMarkerEscaped is the inert rendering of legacyCommandMarker. It
-// keeps the sequence readable and greppable while breaking the runner's match.
-const legacyCommandMarkerEscaped = `##\[`
-
 // sanitizeLogValue renders an untrusted string (a model-authored reason, an
 // artifact filename, or a detection-log line) so it cannot act as a workflow
 // command. Two things are neutralized:
@@ -585,7 +609,7 @@ const legacyCommandMarkerEscaped = `##\[`
 //     runner matches it mid-line and line-position defenses cannot reach it.
 func sanitizeLogValue(s string) string {
 	if !strings.ContainsFunc(s, unicode.IsControl) {
-		return strings.ReplaceAll(s, legacyCommandMarker, legacyCommandMarkerEscaped)
+		return logsafe.EscapeLegacyCommandMarker(s)
 	}
 	var b strings.Builder
 	b.Grow(len(s))
@@ -605,7 +629,7 @@ func sanitizeLogValue(s string) string {
 	}
 	// The control-character escapes above emit only backslash sequences, so they
 	// can neither create nor hide a "##[" marker; escaping it afterwards is safe.
-	return strings.ReplaceAll(b.String(), legacyCommandMarker, legacyCommandMarkerEscaped)
+	return logsafe.EscapeLegacyCommandMarker(b.String())
 }
 
 // truncateRunes shortens s to at most max runes, appending an ellipsis marker
@@ -766,7 +790,16 @@ func (c *concluder) command(kind, message string) {
 
 // escapeWorkflowData escapes a string for use as the data portion of a workflow
 // command, per the GitHub Actions toolkit rules.
+//
+// The toolkit rules cover only the characters that would terminate or extend
+// this command (`%`, CR, LF). They do not cover the legacy `##[` marker, which
+// the runner locates anywhere in a line — including inside the data of a
+// command it is already processing — so annotation text that embeds untrusted
+// content (a parse error quoting a malformed result file, a hostile path) could
+// otherwise smuggle one through. Neutralize it first: the percent-escaping
+// below emits only `%XX` sequences and so can neither create nor hide a marker.
 func escapeWorkflowData(s string) string {
+	s = logsafe.EscapeLegacyCommandMarker(s)
 	s = strings.ReplaceAll(s, "%", "%25")
 	s = strings.ReplaceAll(s, "\r", "%0D")
 	s = strings.ReplaceAll(s, "\n", "%0A")

--- a/cmd/threat-detect/conclude.go
+++ b/cmd/threat-detect/conclude.go
@@ -139,7 +139,7 @@ func runConclude(args []string) int {
 		namedPath{"$GITHUB_OUTPUT", githubOutput},
 		namedPath{"$GITHUB_ENV", githubEnv},
 	); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		stderrf("Error: %v", err)
 		return concludeExitFail
 	}
 
@@ -762,16 +762,25 @@ func (c *concluder) appendKV(path, name, value string) {
 	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "conclude: failed to write %s: %v\n", name, err)
+		stderrf("conclude: failed to write %s: %v", name, err)
 		return
 	}
 	defer f.Close()
 	fmt.Fprintf(f, "%s=%s\n", name, value)
 }
 
-// info prints a human-readable line to stdout (the job log).
+// info prints one diagnostic line to the conclusion's output stream.
+//
+// Sanitizing here rather than at each call site makes this the single choke
+// point for the conclusion diagnostics: every value these lines interpolate —
+// model-authored reasons, artifact filenames, detection-log lines, and the
+// host-supplied paths and environment values echoed in the header — is rendered
+// inert before it can reach the job log, and a future call site cannot
+// reintroduce the gap by forgetting to escape its own arguments. Sanitizing is
+// idempotent, so callers that additionally bound a value may keep escaping it
+// themselves.
 func (c *concluder) info(message string) {
-	fmt.Fprintln(c.stdout, message)
+	fmt.Fprintln(c.stdout, sanitizeLogValue(message))
 }
 
 // banner prints a title framed by horizontal rules, delimiting the conclusion
@@ -792,12 +801,15 @@ func (c *concluder) command(kind, message string) {
 // command, per the GitHub Actions toolkit rules.
 //
 // The toolkit rules cover only the characters that would terminate or extend
-// this command (`%`, CR, LF). They do not cover the legacy `##[` marker, which
-// the runner locates anywhere in a line — including inside the data of a
-// command it is already processing — so annotation text that embeds untrusted
-// content (a parse error quoting a malformed result file, a hostile path) could
-// otherwise smuggle one through. Neutralize it first: the percent-escaping
-// below emits only `%XX` sequences and so can neither create nor hide a marker.
+// this command (`%`, CR, LF); they leave the legacy `##[` marker alone. The
+// runner does not currently rescan the data of a command it has already
+// recognized — it tries the `::` form first and falls back to legacy parsing
+// only when that fails — so a marker embedded in the message of an `::error::`
+// this program emits is not live today. Neutralizing it anyway costs nothing
+// and does not depend on that parse order holding, and it keeps annotation text
+// consistent with the same value rendered by sanitizeLogValue elsewhere in the
+// log. The percent-escaping below emits only `%XX` sequences, so it can neither
+// create nor hide a marker.
 func escapeWorkflowData(s string) string {
 	s = logsafe.EscapeLegacyCommandMarker(s)
 	s = strings.ReplaceAll(s, "%", "%25")

--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -1018,10 +1018,11 @@ func TestConcludeDiagnosticsCannotEmitLegacyWorkflowCommand(t *testing.T) {
 // TestConcludeAnnotationCannotEmitLegacyWorkflowCommand verifies the workflow
 // *command data* path is neutralized too. A parse error quotes the offending
 // value from the result file, and that message is emitted as the data portion
-// of an "::error::" annotation. The toolkit's data escaping covers only "%",
-// CR, and LF, so without an explicit pass the legacy marker — which the runner
-// matches anywhere, including inside a command it is already processing —
-// would ride through.
+// of an "::error::" annotation, which the toolkit's escaping does not clear of
+// legacy markers. The runner does not currently rescan the data of a command it
+// has already recognized, so this is defense in depth rather than a live
+// exposure — but it keeps the annotation consistent with the same value as
+// rendered everywhere else in the log.
 func TestConcludeAnnotationCannotEmitLegacyWorkflowCommand(t *testing.T) {
 	dir := t.TempDir()
 	resultFile := filepath.Join(dir, "detection_result.json")
@@ -1560,4 +1561,41 @@ func captureStdout(t *testing.T, fn func()) string {
 	out := <-done
 	r.Close()
 	return out
+}
+
+// TestConcludeHeaderDiagnosticsNeutralizeLegacyWorkflowCommand covers the
+// header lines, which echo the host-supplied environment values and paths
+// before any verdict is read. They are the earliest untrusted echo in the
+// conclusion, and they are emitted through c.info rather than through the
+// annotation path, so they need the choke point to be doing its job.
+func TestConcludeHeaderDiagnosticsNeutralizeLegacyWorkflowCommand(t *testing.T) {
+	dir := t.TempDir()
+	resultFile := filepath.Join(dir, "##[add-mask]result.json")
+	verdict := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,"reasons":[]}`
+	if err := os.WriteFile(resultFile, []byte(verdict), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	c := &concluder{
+		runDetection:     "true",
+		executionOutcome: "##[stop-commands]outcome",
+		githubOutput:     filepath.Join(dir, "out"),
+		githubEnv:        filepath.Join(dir, "env"),
+		stdout:           &stdout,
+	}
+	if code := c.run(resultFile); code != concludeExitProceed {
+		t.Fatalf("exit code = %d, want %d", code, concludeExitProceed)
+	}
+	got := stdout.String()
+	if strings.Contains(got, "##[") {
+		t.Fatalf("live legacy workflow-command marker reached the log:\n%s", got)
+	}
+	// The values must still be present and readable, just inert.
+	if !strings.Contains(got, `##\[add-mask]result.json`) {
+		t.Fatalf("escaped result path not rendered:\n%s", got)
+	}
+	if !strings.Contains(got, `##\[stop-commands]outcome`) {
+		t.Fatalf("escaped execution outcome not rendered:\n%s", got)
+	}
 }

--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -901,7 +901,8 @@ func TestConcludeReasonCannotInjectWorkflowCommand(t *testing.T) {
 }
 
 // TestReasonLogLines verifies multi-line reasons keep their line structure,
-// stay individually sanitized and bounded, and are capped in line count.
+// stay individually sanitized, are wrapped rather than truncated, and are
+// capped in line count.
 func TestReasonLogLines(t *testing.T) {
 	got := reasonLogLines("LOCATION: prompt.txt:42\r\nEVIDENCE: ignore\tprior\rrules")
 	want := []string{"LOCATION: prompt.txt:42", `EVIDENCE: ignore\tprior`, "rules"}
@@ -914,11 +915,27 @@ func TestReasonLogLines(t *testing.T) {
 		}
 	}
 
+	// An over-long source line is wrapped, not truncated: the forensic detail a
+	// reason exists to carry must survive rendering.
 	long := strings.Repeat("x", maxEchoedLineRunes+50)
-	if lines := reasonLogLines(long); !strings.HasSuffix(lines[0], "… (truncated)") {
-		t.Errorf("over-long line not truncated: %q", lines[0])
+	lines := reasonLogLines(long)
+	if len(lines) != 2 {
+		t.Fatalf("over-long line = %d lines, want 2", len(lines))
+	}
+	if strings.Join(lines, "") != long {
+		t.Errorf("wrapped line lost content: %q", lines)
+	}
+	if len([]rune(lines[0])) != maxEchoedLineRunes {
+		t.Errorf("first segment = %d runes, want %d", len([]rune(lines[0])), maxEchoedLineRunes)
 	}
 
+	// Wrapping must not split a multi-byte rune.
+	wide := reasonLogLines(strings.Repeat("é", maxEchoedLineRunes+1))
+	if len([]rune(wide[0])) != maxEchoedLineRunes || wide[1] != "é" {
+		t.Errorf("multi-byte wrap = %q", wide)
+	}
+
+	// Wrapping is still bounded overall, so one reason cannot flood the log.
 	many := reasonLogLines(strings.Repeat("a\n", maxReasonLogLines+10))
 	if len(many) != maxReasonLogLines+1 {
 		t.Fatalf("line count = %d, want %d", len(many), maxReasonLogLines+1)
@@ -995,6 +1012,44 @@ func TestConcludeDiagnosticsCannotEmitLegacyWorkflowCommand(t *testing.T) {
 
 	if strings.Contains(stdout.String(), "##[") {
 		t.Fatalf("live legacy workflow-command marker reached the log:\n%s", stdout.String())
+	}
+}
+
+// TestConcludeAnnotationCannotEmitLegacyWorkflowCommand verifies the workflow
+// *command data* path is neutralized too. A parse error quotes the offending
+// value from the result file, and that message is emitted as the data portion
+// of an "::error::" annotation. The toolkit's data escaping covers only "%",
+// CR, and LF, so without an explicit pass the legacy marker — which the runner
+// matches anywhere, including inside a command it is already processing —
+// would ride through.
+func TestConcludeAnnotationCannotEmitLegacyWorkflowCommand(t *testing.T) {
+	dir := t.TempDir()
+	resultFile := filepath.Join(dir, "detection_result.json")
+	malformed := `{"prompt_injection":false,"secret_leak":false,"malicious_patch":false,` +
+		`"reasons":[],"##[stop-commands]pwn3d":1}`
+	if err := os.WriteFile(resultFile, []byte(malformed), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	c := &concluder{
+		runDetection: "true",
+		githubOutput: filepath.Join(dir, "out"),
+		githubEnv:    filepath.Join(dir, "env"),
+		stdout:       &stdout,
+	}
+	if code := c.run(resultFile); code != concludeExitFail {
+		t.Fatalf("exit code = %d, want %d", code, concludeExitFail)
+	}
+	got := stdout.String()
+	if strings.Contains(got, "##[") {
+		t.Fatalf("live legacy workflow-command marker reached the log:\n%s", got)
+	}
+	if !strings.Contains(got, `##\[stop-commands]pwn3d`) {
+		t.Fatalf("neutralized field name should stay visible:\n%s", got)
+	}
+	if !strings.Contains(got, "::error::") {
+		t.Fatalf("expected ::error:: annotation, got:\n%s", got)
 	}
 }
 

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/github/gh-aw-threat-detection/pkg/artifacts"
 	"github.com/github/gh-aw-threat-detection/pkg/detector"
 	"github.com/github/gh-aw-threat-detection/pkg/engine"
+	"github.com/github/gh-aw-threat-detection/pkg/logsafe"
 )
 
 const (
@@ -327,9 +328,15 @@ func run() (code int) {
 	// Surface the resolved workflow context on stderr so a dropped CUSTOM_PROMPT
 	// or missing workflow name/description is diagnosable from the job log alone,
 	// not silently absorbed into the prompt.
+	//
+	// Quoting already confines each value to one physical line, but it leaves a
+	// legacy "##[" marker intact, and the runner honors that one anywhere in a
+	// line. Quoting emits backslash escapes only, so it can neither create nor
+	// hide a marker, and escaping afterwards is enough.
 	fmt.Fprintf(os.Stderr,
-		"Prompt context: workflow_name=%q (defaulted=%t) workflow_description=%q (defaulted=%t) custom_prompt_applied=%t custom_prompt_source=%s custom_prompt_bytes=%d\n",
-		arts.WorkflowName, nameDefaulted, arts.WorkflowDescription, descriptionDefaulted,
+		"Prompt context: workflow_name=%s (defaulted=%t) workflow_description=%s (defaulted=%t) custom_prompt_applied=%t custom_prompt_source=%s custom_prompt_bytes=%d\n",
+		logsafe.EscapeLegacyCommandMarker(strconv.Quote(arts.WorkflowName)), nameDefaulted,
+		logsafe.EscapeLegacyCommandMarker(strconv.Quote(arts.WorkflowDescription)), descriptionDefaulted,
 		arts.CustomPrompt != "", customPromptSource, len(arts.CustomPrompt))
 
 	// Build the prompt

--- a/cmd/threat-detect/main.go
+++ b/cmd/threat-detect/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/github/gh-aw-threat-detection/pkg/artifacts"
 	"github.com/github/gh-aw-threat-detection/pkg/detector"
 	"github.com/github/gh-aw-threat-detection/pkg/engine"
-	"github.com/github/gh-aw-threat-detection/pkg/logsafe"
 )
 
 const (
@@ -69,9 +68,24 @@ const (
 // distinguish engine_error from invalid_report_exhausted on the status line.
 var errEngineExecution = errors.New("engine execution failed")
 
+// stderrf writes one diagnostic line to standard error.
+//
+// Every detector diagnostic goes through here so that sanitization is a
+// property of the output path rather than of each call site. The lines
+// interpolate untrusted and host-supplied values — artifact filenames and
+// inventory paths, the artifacts directory, engine and model identifiers,
+// result paths, and error text that quotes any of them — and a future call site
+// must not be able to reintroduce a log-injection gap by forgetting to escape
+// its own arguments. The message is rendered as exactly one physical line, so
+// callers pass no trailing newline. Sanitizing is idempotent, so a caller that
+// additionally bounds a value may still escape it itself.
+func stderrf(format string, args ...any) {
+	fmt.Fprintln(os.Stderr, sanitizeLogValue(fmt.Sprintf(format, args...)))
+}
+
 // emitStatus writes the single terminal status line to stderr.
 func emitStatus(reason string, code int) {
-	fmt.Fprintf(os.Stderr, "%s reason=%s exit=%d\n", statusPrefix, reason, code)
+	stderrf("%s reason=%s exit=%d", statusPrefix, reason, code)
 }
 
 // detectionContinueOnError reports whether the host selected warn mode. It is
@@ -164,7 +178,7 @@ func run() (code int) {
 		}
 	})
 	if stepSummaryProvided {
-		fmt.Fprintf(os.Stderr, "[threat-detect] ignoring deprecated --step-summary %s: the detector no longer writes a step summary\n",
+		stderrf("[threat-detect] ignoring deprecated --step-summary %s: the detector no longer writes a step summary",
 			sanitizeLogValue(stepSummary))
 	}
 
@@ -183,14 +197,14 @@ func run() (code int) {
 	if modelDesc == "" {
 		modelDesc = "(none; using engine default)"
 	}
-	fmt.Fprintf(os.Stderr, "[threat-detect] run start: version=%s engine=%s model=%s retries=%d\n",
+	stderrf("[threat-detect] run start: version=%s engine=%s model=%s retries=%d",
 		sanitizeLogValue(detector.Version), sanitizeLogValue(engine.Canonical(engineID)),
 		sanitizeLogValue(modelDesc), retries)
 
 	// Determine artifacts directory from positional args
 	args := flag.Args()
 	if len(args) < 1 {
-		fmt.Fprintf(os.Stderr, "Usage: threat-detect [flags] <artifacts-dir>\n")
+		stderrf("Usage: threat-detect [flags] <artifacts-dir>")
 		flag.PrintDefaults()
 		reason = reasonConfigError
 		return exitError
@@ -200,7 +214,7 @@ func run() (code int) {
 	// Load artifacts
 	arts, err := artifacts.Load(artifactsDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading artifacts: %v\n", err)
+		stderrf("Error loading artifacts: %v", err)
 		reason = reasonConfigError
 		return exitError
 	}
@@ -226,12 +240,12 @@ func run() (code int) {
 		if w.RequiredInput && !warnMode {
 			command = "error"
 		}
-		fmt.Fprintf(os.Stderr, "::%s::%s\n", command, escapeWorkflowData(w.Message))
+		stderrf("::%s::%s", command, escapeWorkflowData(w.Message))
 		// The annotation text alone does not say whether the finding concerns an
 		// artifact the host was required to stage — in warn mode both kinds are
 		// emitted as "::warning::". Record that classification alongside it so
 		// TD-18c stays diagnosable from the job log.
-		fmt.Fprintf(os.Stderr, "[threat-detect] artifact degraded: field=%s required_input=%t\n",
+		stderrf("[threat-detect] artifact degraded: field=%s required_input=%t",
 			sanitizeLogValue(w.Field), w.RequiredInput)
 	}
 
@@ -239,13 +253,13 @@ func run() (code int) {
 	// analyze nothing and return a clean verdict — a fail-open failure mode in
 	// a security control. Fail closed instead of proceeding.
 	if arts.AllPrimaryInputsMissing {
-		fmt.Fprintf(os.Stderr, "Error: prompt, agent output, and patch/bundle files are all missing or empty in %s; refusing to run detection on empty input.\n", artifactsDir)
+		stderrf("Error: prompt, agent output, and patch/bundle files are all missing or empty in %s; refusing to run detection on empty input.", artifactsDir)
 		reason = reasonConfigError
 		return exitError
 	}
 
 	if !warnMode && arts.HasRequiredInputWarnings() {
-		fmt.Fprintf(os.Stderr, "Error: one or more required detection inputs in %s are missing or unusable and GH_AW_DETECTION_CONTINUE_ON_ERROR is \"false\"; refusing to run degraded detection.\n", artifactsDir)
+		stderrf("Error: one or more required detection inputs in %s are missing or unusable and GH_AW_DETECTION_CONTINUE_ON_ERROR is \"false\"; refusing to run degraded detection.", artifactsDir)
 		reason = reasonConfigError
 		return exitError
 	}
@@ -276,20 +290,20 @@ func run() (code int) {
 	if outputJSON != "" && fullOutputJSON != "" {
 		same, err := samePath(outputJSON, fullOutputJSON)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error resolving result paths: %v\n", err)
+			stderrf("Error resolving result paths: %v", err)
 			reason = reasonConfigError
 			return exitError
 		}
 		if same {
-			fmt.Fprintf(os.Stderr, "Error: --full-output %s resolves to the same file as --output; the full result must be written to a separate path that the host does not upload.\n",
-				sanitizeLogValue(fullOutputJSON))
+			stderrf("Error: --full-output %s resolves to the same file as --output; the full result must be written to a separate path that the host does not upload.",
+				fullOutputJSON)
 			reason = reasonConfigError
 			return exitError
 		}
 	}
-	fmt.Fprintf(os.Stderr, "[threat-detect] result destinations: output=%s full_output=%s\n",
-		sanitizeLogValue(describeResultPath(outputJSON, "(stdout)")),
-		sanitizeLogValue(describeResultPath(fullOutputJSON, "(disabled)")))
+	stderrf("[threat-detect] result destinations: output=%s full_output=%s",
+		describeResultPath(outputJSON, "(stdout)"),
+		describeResultPath(fullOutputJSON, "(disabled)"))
 
 	// A value is "defaulted" only when neither the flag nor its environment
 	// variable supplied it; equality with the fallback text is not sufficient.
@@ -317,7 +331,7 @@ func run() (code int) {
 	if providedFlags["custom-prompt-file"] {
 		data, err := os.ReadFile(customPromptFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading custom prompt file: %v\n", err)
+			stderrf("Error reading custom prompt file: %v", err)
 			reason = reasonConfigError
 			return exitError
 		}
@@ -329,14 +343,11 @@ func run() (code int) {
 	// or missing workflow name/description is diagnosable from the job log alone,
 	// not silently absorbed into the prompt.
 	//
-	// Quoting already confines each value to one physical line, but it leaves a
-	// legacy "##[" marker intact, and the runner honors that one anywhere in a
-	// line. Quoting emits backslash escapes only, so it can neither create nor
-	// hide a marker, and escaping afterwards is enough.
-	fmt.Fprintf(os.Stderr,
-		"Prompt context: workflow_name=%s (defaulted=%t) workflow_description=%s (defaulted=%t) custom_prompt_applied=%t custom_prompt_source=%s custom_prompt_bytes=%d\n",
-		logsafe.EscapeLegacyCommandMarker(strconv.Quote(arts.WorkflowName)), nameDefaulted,
-		logsafe.EscapeLegacyCommandMarker(strconv.Quote(arts.WorkflowDescription)), descriptionDefaulted,
+	// The workflow name and description originate outside the detector, so they
+	// are quoted for readability here and rendered inert by stderrf.
+	stderrf(
+		"Prompt context: workflow_name=%q (defaulted=%t) workflow_description=%q (defaulted=%t) custom_prompt_applied=%t custom_prompt_source=%s custom_prompt_bytes=%d",
+		arts.WorkflowName, nameDefaulted, arts.WorkflowDescription, descriptionDefaulted,
 		arts.CustomPrompt != "", customPromptSource, len(arts.CustomPrompt))
 
 	// Build the prompt
@@ -344,7 +355,7 @@ func run() (code int) {
 	if promptFile != "" {
 		data, err := os.ReadFile(promptFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading prompt template: %v\n", err)
+			stderrf("Error reading prompt template: %v", err)
 			reason = reasonConfigError
 			return exitError
 		}
@@ -353,7 +364,7 @@ func run() (code int) {
 
 	prompt, promptAnalysis, err := detector.BuildPromptWithAnalysis(arts, promptTemplate)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error building prompt: %v\n", err)
+		stderrf("Error building prompt: %v", err)
 		reason = reasonConfigError
 		return exitError
 	}
@@ -365,8 +376,8 @@ func run() (code int) {
 	if markers := scaffoldingMarkers(promptAnalysis); len(markers) > 0 {
 		scaffoldingDesc = sanitizeLogValue(strings.Join(markers, ", "))
 	}
-	fmt.Fprintf(os.Stderr,
-		"[threat-detect] prompt built: prompt_bytes=%d framework_scaffolding_detected=%t framework_scaffolding_host_removed=%t framework_scaffolding_markers=%s\n",
+	stderrf(
+		"[threat-detect] prompt built: prompt_bytes=%d framework_scaffolding_detected=%t framework_scaffolding_host_removed=%t framework_scaffolding_markers=%s",
 		len(prompt),
 		promptAnalysis != nil && promptAnalysis.Scaffolding != nil && promptAnalysis.Scaffolding.Detected,
 		promptAnalysis != nil && promptAnalysis.Scaffolding != nil && promptAnalysis.Scaffolding.HostRemoved,
@@ -375,7 +386,7 @@ func run() (code int) {
 	// Create engine
 	eng, err := engine.New(engineID, model)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating engine: %v\n", err)
+		stderrf("Error creating engine: %v", err)
 		reason = reasonConfigError
 		return exitError
 	}
@@ -383,7 +394,7 @@ func run() (code int) {
 	// Provision an out-of-band result sink for the in-session reporting tool.
 	sinkFile, err := os.CreateTemp("", "threat-detect-result-*.json")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating result sink: %v\n", err)
+		stderrf("Error creating result sink: %v", err)
 		reason = reasonConfigError
 		return exitError
 	}
@@ -396,8 +407,8 @@ func run() (code int) {
 	result, err := analyzeWithRetries(ctx, eng, prompt, sinkPath, retries)
 	if err != nil {
 		// The message can embed captured engine output (engineExitError), which
-		// is untrusted: sanitize it so it cannot break out of this line.
-		fmt.Fprintf(os.Stderr, "Error running detection: %s\n", sanitizeLogValue(err.Error()))
+		// is untrusted; stderrf renders it inert.
+		stderrf("Error running detection: %v", err)
 		switch {
 		case ctx.Err() != nil:
 			reason = reasonCancelled
@@ -430,26 +441,26 @@ func describeResultPath(path, placeholder string) string {
 // directory, so each is sanitized and confined to one physical line; the listing
 // is bounded so a pathological directory cannot flood the job log.
 func reportArtifacts(artifactsDir string, arts *artifacts.Artifacts) {
-	fmt.Fprintf(os.Stderr,
-		"[threat-detect] artifacts loaded: dir=%s prompt_bytes=%d agent_output_bytes=%d patch_files=%d all_primary_inputs_missing=%t\n",
+	stderrf(
+		"[threat-detect] artifacts loaded: dir=%s prompt_bytes=%d agent_output_bytes=%d patch_files=%d all_primary_inputs_missing=%t",
 		sanitizeLogValue(artifactsDir), arts.PromptFileSize, arts.AgentOutputFileSize,
 		len(arts.PatchFiles), arts.AllPrimaryInputsMissing)
 
 	if len(arts.Inventory) == 0 {
-		fmt.Fprintf(os.Stderr, "[threat-detect] artifact inventory: (empty)\n")
+		stderrf("[threat-detect] artifact inventory: (empty)")
 		return
 	}
 	shown := arts.Inventory
 	if len(shown) > maxInventoryEntries {
 		shown = shown[:maxInventoryEntries]
 	}
-	fmt.Fprintf(os.Stderr, "[threat-detect] artifact inventory (%d entries):\n", len(arts.Inventory))
+	stderrf("[threat-detect] artifact inventory (%d entries):", len(arts.Inventory))
 	for _, entry := range shown {
-		fmt.Fprintf(os.Stderr, "[threat-detect]   %s bytes=%d kind=%s consumed=%t\n",
+		stderrf("[threat-detect]   %s bytes=%d kind=%s consumed=%t",
 			sanitizeLogValue(entry.Path), entry.Size, sanitizeLogValue(entry.Kind), entry.Consumed)
 	}
 	if len(shown) < len(arts.Inventory) {
-		fmt.Fprintf(os.Stderr, "[threat-detect]   ... %d more entry(ies) omitted\n", len(arts.Inventory)-len(shown))
+		stderrf("[threat-detect]   ... %d more entry(ies) omitted", len(arts.Inventory)-len(shown))
 	}
 }
 
@@ -474,9 +485,8 @@ func warnDegradedPromptAnalysis(analysis *detector.PromptAnalysis) {
 		return
 	}
 
-	fmt.Fprintf(
-		os.Stderr,
-		"::warning::%s: Missing or unusable prompt analysis artifacts: %s. Trusted-vs-untrusted prompt analysis is degraded; ensure the host stages both non-empty files.\n",
+	stderrf(
+		"::warning::%s: Missing or unusable prompt analysis artifacts: %s. Trusted-vs-untrusted prompt analysis is degraded; ensure the host stages both non-empty files.",
 		promptAnalysisValidationCode,
 		strings.Join(unavailable, ", "),
 	)
@@ -493,7 +503,7 @@ func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath
 	currentPrompt := prompt
 	var lastErr error
 	for i := 0; i < attempts; i++ {
-		fmt.Fprintf(os.Stderr, "[threat-detect] detection attempt %d of %d\n", i+1, attempts)
+		stderrf("[threat-detect] detection attempt %d of %d", i+1, attempts)
 		// Remove any stale sink result before each attempt.
 		os.Remove(sinkPath)
 		if _, err := eng.Analyze(ctx, currentPrompt, engine.AnalyzeOptions{ResultSinkPath: sinkPath}); err != nil {
@@ -503,11 +513,11 @@ func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath
 		// threat_detection_result tool, which records it to the sink.
 		result, err := detector.ReadResultFile(sinkPath)
 		if err == nil {
-			fmt.Fprintf(os.Stderr, "[threat-detect] attempt %d recorded a verdict via the threat_detection_result tool\n", i+1)
+			stderrf("[threat-detect] attempt %d recorded a verdict via the threat_detection_result tool", i+1)
 			return result, nil
 		}
 		lastErr = err
-		fmt.Fprintf(os.Stderr, "[threat-detect] attempt %d recorded no usable verdict: %s\n", i+1, sanitizeLogValue(err.Error()))
+		stderrf("[threat-detect] attempt %d recorded no usable verdict: %v", i+1, err)
 		currentPrompt = detector.BuildCorrectionPrompt(prompt, detectionCorrectionPrefix, detectionCorrectionMessage, detectionCorrectionInstruction)
 	}
 	return nil, fmt.Errorf("detection model did not record a verdict via the threat_detection_result tool after %d attempt(s): %w", attempts, lastErr)
@@ -535,10 +545,10 @@ func analyzeWithRetries(ctx context.Context, eng engine.Engine, prompt, sinkPath
 func writeResult(result *detector.Result, outputJSON, fullOutputJSON string) (int, string) {
 	if fullOutputJSON != "" {
 		if err := detector.WriteResultFile(fullOutputJSON, result); err != nil {
-			fmt.Fprintf(os.Stderr, "::warning::Could not write the full detection result to %s: %v. The verdict is unaffected; reasons will not be available to the conclusion step.\n",
+			stderrf("::warning::Could not write the full detection result to %s: %v. The verdict is unaffected; reasons will not be available to the conclusion step.",
 				escapeWorkflowData(fullOutputJSON), escapeWorkflowData(err.Error()))
 		} else {
-			fmt.Fprintf(os.Stderr, "[threat-detect] full result written: path=%s reasons=%d\n",
+			stderrf("[threat-detect] full result written: path=%s reasons=%d",
 				sanitizeLogValue(fullOutputJSON), len(result.Reasons))
 		}
 	}
@@ -546,13 +556,13 @@ func writeResult(result *detector.Result, outputJSON, fullOutputJSON string) (in
 	redacted := result.Redacted()
 	jsonBytes, err := json.MarshalIndent(redacted, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error marshaling result: %v\n", err)
+		stderrf("Error marshaling result: %v", err)
 		return exitError, reasonOutputWriteError
 	}
 
 	if outputJSON != "" {
 		if err := os.WriteFile(outputJSON, jsonBytes, 0o600); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing output: %v\n", err)
+			stderrf("Error writing output: %v", err)
 			return exitError, reasonOutputWriteError
 		}
 	} else {

--- a/cmd/threat-detect/main_test.go
+++ b/cmd/threat-detect/main_test.go
@@ -993,3 +993,28 @@ func TestRunAcceptsAndIgnoresStepSummaryFlag(t *testing.T) {
 		t.Errorf("expected no step summary to be written to %s, stat err = %v", summaryPath, err)
 	}
 }
+
+// TestDetectionDiagnosticsNeutralizeLegacyWorkflowCommand covers the detection
+// run's own stderr diagnostics. The artifacts directory is host-supplied and is
+// echoed verbatim in the fail-closed error, so — like every other detector
+// diagnostic — it must not be able to emit the runner's legacy workflow command
+// from mid-line.
+func TestDetectionDiagnosticsNeutralizeLegacyWorkflowCommand(t *testing.T) {
+	artifactsDir := filepath.Join(t.TempDir(), "##[stop-commands]artifacts")
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	code, stderr := runWithTestArgsCapture(t, []string{"threat-detect", artifactsDir}, nil)
+
+	if code != exitError {
+		t.Fatalf("run() exit code = %d, want %d; stderr:\n%s", code, exitError, stderr)
+	}
+	if strings.Contains(stderr, "##[") {
+		t.Fatalf("live legacy workflow-command marker reached the log:\n%s", stderr)
+	}
+	// The path must still be present and readable, just inert.
+	if !strings.Contains(stderr, `##\[stop-commands]artifacts`) {
+		t.Fatalf("escaped artifacts dir not rendered:\n%s", stderr)
+	}
+}

--- a/cmd/threat-detect/promptcontext_test.go
+++ b/cmd/threat-detect/promptcontext_test.go
@@ -175,3 +175,29 @@ func TestPromptContextRejectsUnreadableCustomPromptFile(t *testing.T) {
 		t.Fatalf("stderr missing config_error status, got:\n%s", stderr)
 	}
 }
+
+func TestPromptContextNeutralizesLegacyWorkflowCommand(t *testing.T) {
+	// The workflow name and description are echoed verbatim into the job log.
+	// Quoting confines them to one line but leaves the legacy "##[command]"
+	// marker intact, and the runner matches that one anywhere in a line.
+	stderr := runDetectionForPromptContext(t, map[string]string{
+		"WORKFLOW_NAME":        "##[add-mask]name",
+		"WORKFLOW_DESCRIPTION": "desc ##[stop-commands]tok",
+	})
+
+	promptContext := ""
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.HasPrefix(line, "Prompt context:") {
+			promptContext = line
+		}
+	}
+	if promptContext == "" {
+		t.Fatalf("stderr missing prompt context line, got:\n%s", stderr)
+	}
+	if strings.Contains(promptContext, "##[") {
+		t.Fatalf("live legacy workflow-command marker reached the log: %q", promptContext)
+	}
+	if !strings.Contains(promptContext, `add-mask]name`) || !strings.Contains(promptContext, `stop-commands]tok`) {
+		t.Fatalf("neutralized values should stay visible: %q", promptContext)
+	}
+}

--- a/cmd/threat-detect/report.go
+++ b/cmd/threat-detect/report.go
@@ -158,9 +158,14 @@ func reportError(reason string) {
 // emitMessage writes msg to both stdout (so it appears in the model's tool
 // output) and stderr, keeping the THREAT_DETECTION_RESULT_ERROR prefix visible
 // regardless of how the tool output is captured.
+//
+// The message can quote a malformed reasons file, so the stderr copy — the one
+// bound for a job log — is rendered inert. The stdout copy is left verbatim: it
+// is the model's own tool output, and it reaches a job log only by way of the
+// engine transcript, which is framed and neutralized as it is forwarded.
 func emitMessage(msg string) {
 	fmt.Println(msg)
-	fmt.Fprintln(os.Stderr, msg)
+	stderrf("%s", msg)
 }
 
 func toAnySlice(values []string) []any {

--- a/pkg/engine/passthrough.go
+++ b/pkg/engine/passthrough.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"strings"
 	"sync"
+
+	"github.com/github/gh-aw-threat-detection/pkg/logsafe"
 )
 
 // PassthroughPrefix is prepended to every line of engine subprocess output that
@@ -112,11 +114,20 @@ func (w *passthroughWriter) flushLocked() {
 }
 
 // neutralizeWorkflowCommand defuses a line that tries to open a GitHub Actions
-// workflow command (::error::, ::stop-commands::, ...). The frame prefix already
-// prevents the runner from seeing one, since a framed line no longer starts with
-// "::"; this is defense in depth for consumers that strip the prefix, and it
-// keeps the intent visible in the log rather than silently dropping it.
+// workflow command, in both marker forms the runner accepts.
+//
+// The `::command::` form is only honored at the start of a line (after trimming
+// leading whitespace), so the frame prefix already prevents the runner from
+// seeing one; rewriting it is defense in depth for consumers that strip the
+// prefix, and it keeps the intent visible in the log rather than silently
+// dropping it.
+//
+// The legacy `##[command]` form is different in kind: the runner locates it
+// anywhere within a line, so neither the frame prefix nor any indentation makes
+// it inert. It must be broken up inside the value itself, exactly as the
+// detector's own diagnostics do.
 func neutralizeWorkflowCommand(line string) string {
+	line = logsafe.EscapeLegacyCommandMarker(line)
 	trimmed := strings.TrimLeft(line, " \t")
 	if !strings.HasPrefix(trimmed, "::") {
 		return line

--- a/pkg/engine/passthrough_test.go
+++ b/pkg/engine/passthrough_test.go
@@ -77,6 +77,31 @@ func TestPassthrough_InjectedWorkflowCommand(t *testing.T) {
 	}
 }
 
+func TestPassthrough_InjectedLegacyWorkflowCommand(t *testing.T) {
+	// The runner locates the legacy "##[command]" marker anywhere within a
+	// line, so the "[engine] " frame is no defense: an engine echoing
+	// attacker-authored artifact text could otherwise emit ##[stop-commands]
+	// (suppressing the detector's own threat annotation) or ##[add-mask]
+	// (redacting the log a maintainer is meant to read). The marker must be
+	// broken up inside the value itself.
+	got := capturePassthrough(t,
+		"tool wrote: harmless ##[stop-commands]pwn3d\n"+
+			"##[add-mask]secret\n")
+
+	if strings.Contains(got, "##[") {
+		t.Fatalf("live legacy workflow-command marker survived framing: %q", got)
+	}
+	// The evidence must still be readable, just inert.
+	if !strings.Contains(got, `##\[stop-commands]pwn3d`) || !strings.Contains(got, `##\[add-mask]secret`) {
+		t.Fatalf("neutralized content should stay visible, got %q", got)
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(got, "\n"), "\n") {
+		if !strings.HasPrefix(line, PassthroughPrefix) {
+			t.Errorf("line is not framed: %q", line)
+		}
+	}
+}
+
 func TestPassthrough_InjectedDetectorMarkers(t *testing.T) {
 	// A forged verdict or status marker must remain distinguishable from a
 	// detector-authored one: every forwarded line carries the frame.

--- a/pkg/logsafe/logsafe.go
+++ b/pkg/logsafe/logsafe.go
@@ -1,0 +1,33 @@
+// Package logsafe holds the renderings that keep untrusted text from acting as
+// a GitHub Actions workflow command when it reaches a job log.
+//
+// It exists as its own package because more than one layer emits untrusted text
+// — the detector's own diagnostics, the conclusion banners, and the forwarded
+// engine subprocess stream — and those layers live in packages that do not
+// otherwise depend on each other. A single definition here is what keeps them
+// from drifting apart, which is exactly how a neutralization gap appears.
+package logsafe
+
+import "strings"
+
+// LegacyCommandMarker is the runner's legacy workflow-command marker,
+// "##[command]data". The Actions runner honors it in addition to the "::" form,
+// and — unlike "::", which it accepts only at the start of a line (after
+// trimming leading whitespace) — it locates this marker with an unanchored
+// search. A legacy marker anywhere inside a log line is therefore a live
+// command, so no line prefix, gutter, or indentation can render it inert: the
+// value itself must be broken up. Reachable commands include add-mask (which
+// redacts arbitrary text from the log) and stop-commands (which suppresses
+// every later command, including the detector's own threat annotation).
+const LegacyCommandMarker = "##["
+
+// LegacyCommandMarkerEscaped is the inert rendering of LegacyCommandMarker. It
+// keeps the sequence readable and greppable while breaking the runner's match.
+const LegacyCommandMarkerEscaped = `##\[`
+
+// EscapeLegacyCommandMarker renders every legacy workflow-command marker in s
+// inert. It is safe to apply after other escaping passes as long as those
+// passes cannot themselves synthesize a "##[" sequence.
+func EscapeLegacyCommandMarker(s string) string {
+	return strings.ReplaceAll(s, LegacyCommandMarker, LegacyCommandMarkerEscaped)
+}

--- a/pkg/logsafe/logsafe_test.go
+++ b/pkg/logsafe/logsafe_test.go
@@ -1,0 +1,44 @@
+package logsafe
+
+import "testing"
+
+func TestEscapeLegacyCommandMarker(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no marker", "plain text ## [not a marker]", "plain text ## [not a marker]"},
+		{"leading marker", "##[add-mask]secret", `##\[add-mask]secret`},
+		{"mid-line marker", "evidence: x ##[stop-commands]tok", `evidence: x ##\[stop-commands]tok`},
+		{"repeated markers", "##[a]##[b]", `##\[a]##\[b]`},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EscapeLegacyCommandMarker(tc.in); got != tc.want {
+				t.Errorf("EscapeLegacyCommandMarker(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEscapedMarkerIsInert guards the property the escaping exists for: no
+// escaped output may still contain a sequence the runner would match.
+func TestEscapedMarkerIsInert(t *testing.T) {
+	// A value crafted so that naively deleting the marker would splice a new
+	// one back together must still come out inert.
+	got := EscapeLegacyCommandMarker("###[##[[error]")
+	if contains(got, LegacyCommandMarker) {
+		t.Fatalf("escaped value still carries a live marker: %q", got)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -135,7 +135,7 @@ result file before parsing it, and MUST reject a file that exceeds that bound as
 a parse error rather than parsing a truncated prefix. The bound MUST be large
 enough to admit every result permitted by TD-10a and TD-10b.
 
-**TD-10d**: `reasons` is model-authored text derived from untrusted input, so it
+**TD-10f**: `reasons` is model-authored text derived from untrusted input, so it
 MUST NOT be persisted in any file the host publishes. The implementation MUST
 therefore split the verdict across two destinations:
 
@@ -335,7 +335,7 @@ trusted framework content in the template copy.
 
 **TD-19**: The detector MUST output the structured JSON result (per TD-08) to
 stdout. That result is the redacted one: its `reasons` array is always empty
-(per TD-10d).
+(per TD-10f).
 
 **TD-20**: The detector MUST support writing the result to a file via the
 `--output` flag, and the companion full result via the `--full-output` flag.
@@ -375,7 +375,12 @@ MUST emit forwarded output one line at a time, MUST prefix every forwarded line
 with a fixed marker that identifies it as engine output, MUST treat both LF and
 CR as line terminators, MUST flush a trailing partial line that arrives without a
 terminator, and MUST ensure no forwarded line can be interpreted by the host as a
-workflow command. A reader MUST therefore be able to distinguish forwarded engine
+workflow command in either marker form of TD-20d. The frame prefix alone
+satisfies this for the `::command::` form, which the runner honors only at the
+start of a line; it does not for the legacy `##[command]` form, which the runner
+locates anywhere within a line and which MUST therefore be neutralized within
+the forwarded text itself. A reader MUST therefore be able to distinguish
+forwarded engine
 output from detector-authored diagnostics by inspecting a single line. Hosts and
 log consumers MUST NOT treat forwarded engine output as detector-attested text,
 and MUST ignore `THREAT_DETECTION_*` markers appearing on forwarded lines.
@@ -437,20 +442,27 @@ NOT report a bounded prefix as though it were the whole input. A model-authored
 reason MAY be rendered across multiple physical lines so its quoted evidence
 stays readable and copy-pasteable (TD-10d); when it is, every line after the
 first MUST be prefixed with a marker that cannot begin a workflow command.
+Where a per-line bound applies to a reason, a line exceeding it MUST be wrapped
+across further physical lines rather than truncated, because a reason within the
+bounds of TD-10b is by definition content the implementation accepted, and
+discarding its located, verbatim evidence would defeat TD-10d.
 Untrusted values echoed into the diagnostics (model-authored reasons, artifact
 filenames, and detection-log lines) MUST otherwise be escaped so that each
-physical output line is confined to one line of the value. Such values MUST NOT
+physical output line carries only the value's own content and cannot start a
+line of its own. Such values MUST NOT
 be able to emit a host workflow command in **either** marker form the runner
 accepts: the `::command::` form, which the runner honors only at the start of a
 line after trimming leading whitespace, and the legacy `##[command]` form, which
 the runner locates anywhere within a line. Because line position is no defense
 against the latter, the legacy marker MUST be neutralized within the value
-itself. These diagnostics
+itself — including when the value is carried as the data portion of a workflow
+command the implementation itself emits, which the runner also scans. These
+diagnostics
 are the sole record of the conclusion; `conclude` MUST NOT write them to any
 separate log artifact (TD-20a).
 
 **TD-20e**: Because the result file read by `conclude` carries no reasons
-(TD-10d), `conclude` MUST recover them from the companion full result. It MUST
+(TD-10f), `conclude` MUST recover them from the companion full result. It MUST
 accept a `--full-result-file <path>` option and, when the option is not given,
 MUST derive the path from `--result-file` using the same convention the
 detection run uses for `--full-output`. An explicitly empty value MUST disable

--- a/specs/threat-detection-spec.md
+++ b/specs/threat-detection-spec.md
@@ -455,8 +455,11 @@ accepts: the `::command::` form, which the runner honors only at the start of a
 line after trimming leading whitespace, and the legacy `##[command]` form, which
 the runner locates anywhere within a line. Because line position is no defense
 against the latter, the legacy marker MUST be neutralized within the value
-itself — including when the value is carried as the data portion of a workflow
-command the implementation itself emits, which the runner also scans. These
+itself. An implementation MAY additionally neutralize the marker in the data
+portion of a workflow command it emits itself. The runner does not currently
+rescan that data — it attempts the `::command::` form first and falls back to
+legacy parsing only when that attempt fails — so this is defense in depth
+against that parse order changing, not a live exposure. These
 diagnostics
 are the sole record of the conclusion; `conclude` MUST NOT write them to any
 separate log artifact (TD-20a).

--- a/specs/usage-spec.md
+++ b/specs/usage-spec.md
@@ -151,7 +151,7 @@ verdict payload and MUST read it from the location it configured (stdout, or the
 `--output` path, or the `detection_result.json` sink used by `conclude`).
 
 **U-08a**: The result the host reads and publishes carries no reasons: its
-`reasons` array is always empty (per TD-10d). The reasons are written to the
+`reasons` array is always empty (per TD-10f). The reasons are written to the
 companion full result (`--full-output`, by default `detection_result_full.json`
 beside the result file). A host MUST NOT upload, publish, or otherwise persist
 the full result; it exists so `conclude` can render the reasons into the job log
@@ -159,7 +159,7 @@ the full result; it exists so `conclude` can render the reasons into the job log
 log retention. A host that needs the reasons after the fact MUST read them from
 the retained job log, not from an artifact.
 
-A host MUST treat failure to write the full result as non-fatal (per TD-10d). If
+A host MUST treat failure to write the full result as non-fatal (per TD-10f). If
 it places the result file in a directory it uploads wholesale rather than by
 exact path, it MUST either point `--full-output` outside that directory or pass
 an explicitly empty `--full-output` to disable it.
@@ -170,7 +170,7 @@ only diagnostic output (per TD-20a). The host MUST NOT publish that capture as a
 artifact: it carries the forwarded engine transcript, which reproduces the
 model-authored reasons wherever the engine renders its own tool activity — in
 particular the file write that produces the reasons file passed to
-`threat_detection_result` (per TD-10d). The job log is the intended
+`threat_detection_result` (per TD-10f). The job log is the intended
 destination for that text; a file uploaded alongside the result is not. The detector does not produce a separate
 run-log artifact and does not write to the GitHub Actions step summary; the
 recursive artifact inventory, the prompt metadata, the per-attempt trace, and the
@@ -187,6 +187,10 @@ versions.
 | `--engine {copilot\|claude\|codex}` | Select the AI engine (default `copilot`) |
 | `--model <name>` | Override the engine model (see U-13) |
 | `--prompt-template <path>` | Override the embedded default prompt |
+| `--workflow-name <name>` | Workflow name folded into the prompt; overrides `WORKFLOW_NAME` |
+| `--workflow-description <text>` | Workflow description folded into the prompt; overrides `WORKFLOW_DESCRIPTION` |
+| `--custom-prompt <text>` | Additional detection instructions appended to the prompt (per TD-11, TD-12); overrides `CUSTOM_PROMPT` |
+| `--custom-prompt-file <path>` | Read the additional instructions from a file; wins over `--custom-prompt` |
 | `--output <path>` | Write the JSON result to a file instead of stdout (reasons always empty, per U-08a) |
 | `--full-output <path>` | Write the result including reasons; defaults to the `--output` path with `_full` inserted before the extension, and an explicitly empty value disables it. MUST NOT be uploaded |
 | `--retries <n>` | Retries for malformed detection outputs (default `1`) |


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01KZY7SHTHBSTWTR2X2YJKAP93)

Follow-up review of the final `v0.4.9` state (#852 + #854). Everything below was found by auditing the merged result against the spec and docs.

## Legacy `##[command]` neutralization was incomplete

#854 correctly established that the Actions runner locates the legacy `##[command]` marker *anywhere* in a line — so no prefix, gutter, or indentation can render it inert — and wrote that into `TD-20d`. But the implementation landed in `sanitizeLogValue` only, leaving the two paths that need it most:

- **`pkg/engine/passthrough.go`** — `neutralizeWorkflowCommand` only defused a leading `::`. The `[engine] ` frame is no defense against the legacy form, and this stream is raw, attacker-quoted artifact text echoed by the engine. `TD-20a` already required that no forwarded line be interpretable as a workflow command.
- **`cmd/threat-detect/conclude.go`** — `escapeWorkflowData` covers only `%`, CR, and LF per the toolkit rules. A parse error quotes the offending value from a malformed result file, and that message becomes the data portion of an `::error::` annotation, which the runner also scans.

Reachable commands include `##[add-mask]` (redacts arbitrary text from the log a maintainer is meant to read) and `##[stop-commands]` (suppresses every later command, including the detector's own threat annotation).

Both now route through one shared definition in a new `pkg/logsafe`. The duplication is the point: these layers live in packages that don't otherwise depend on each other, and a single definition is what stops them drifting apart again — which is exactly how this gap appeared. `main.go`'s prompt-context line gets the same treatment (quoting confined it to one line but left the marker intact).

## Reason rendering truncated away the detail #852 added

`MaxReasonRunes` is 2000, but `reasonLogLines` cut every rendered line at `maxEchoedLineRunes` (500). A reason that simply wasn't pre-wrapped lost up to three quarters of its content — precisely the located, verbatim evidence #852 exists to produce. Long lines are now wrapped across continuation lines (rune-aware, so multi-byte characters are never split) instead of truncated; the overall `maxReasonLogLines` cap still bounds the log, and the `::error::` annotation stays a bounded summary that points back at the verdict block.

## Spec ID collision

`TD-10d` was defined twice: #852 used it for the forensic-reason requirements, then #854 reused it for the redacted/full result split. References resolved ambiguously across both specs and `CLAUDE.md`. The split requirement is renamed **`TD-10f`** (the incumbent `TD-10d` and `TD-10e` keep their meanings), and all references are updated.

## Doc corrections

- The smoke locks conclude with gh-aw's `conclude_threat_detection.sh`, **not** `threat-detect conclude`, so they never perform the `--full-result-file` lookup and their job logs show no reasons. README and `CLAUDE.md` claimed otherwise; both now say so explicitly and point at `replay-detection.yml` when the reasons are what you need.
- README's log-safety paragraph now names both marker forms rather than claiming single-line confinement generally.
- `TD-20a`/`TD-20d` state the two-marker-form requirement and the wrap-don't-truncate rule normatively.
- `usage-spec.md`'s flag table was missing `--workflow-name`, `--workflow-description`, `--custom-prompt`, and `--custom-prompt-file`.
- "one-shot self-correction" corrected to reflect that `--retries` can exceed 1.

## Testing

New coverage for each closed gap: engine passthrough legacy markers, the `::error::` annotation data path, the prompt-context line, reason wrapping (including a multi-byte rune boundary), and the `pkg/logsafe` escaping itself.

`make fmt lint build test` all pass. `gosec` reports the same 40 findings as `v0.4.9` — it fails identically on the base tag in this environment, so no regression; `golangci-lint` is unrunnable here (its Go 1.25 build vs. the module's 1.26 target).

No behavior change for hosts: the JSON contract, flags, and exit codes are untouched.