### PR TITLE
fix(smokes): require strictly sequential steps in standalone smoke prompts

### DIFF
--- a/.github/workflows/smoke-claude-standalone.md
+++ b/.github/workflows/smoke-claude-standalone.md
@@ -67,6 +67,13 @@ run and wait for it **once**, for at most 5 minutes total. If it has not
 finished by then, record ❌ for that check and move on to the next
 requirement — do not keep waiting.
 
+Run the test requirements below **strictly in order**. Do not start step N+1
+until step N has completed and you have observed its exit code. Do not issue
+tool calls in parallel — dispatch one command, wait for it to finish, then
+dispatch the next. In particular, `./bin/threat-detect --version` depends on
+`make build` from the previous step and MUST NOT be launched before that build
+has returned.
+
 ## Test Requirements
 
 1. Use GitHub tools to read the latest 2 pull requests in `${{ github.repository }}` and record their numbers and titles only.

--- a/.github/workflows/smoke-codex-standalone.md
+++ b/.github/workflows/smoke-codex-standalone.md
@@ -65,6 +65,13 @@ run and wait for it **once**, for at most 5 minutes total. If it has not
 finished by then, record ❌ for that check and move on to the next
 requirement — do not keep waiting.
 
+Run the test requirements below **strictly in order**. Do not start step N+1
+until step N has completed and you have observed its exit code. Do not issue
+tool calls in parallel — dispatch one command, wait for it to finish, then
+dispatch the next. In particular, `./bin/threat-detect --version` depends on
+`make build` from the previous step and MUST NOT be launched before that build
+has returned.
+
 ## Test Requirements
 
 1. Use GitHub tools to read the latest 2 pull requests in `${{ github.repository }}` and record their numbers and titles only.

--- a/.github/workflows/smoke-copilot-standalone.md
+++ b/.github/workflows/smoke-copilot-standalone.md
@@ -65,6 +65,13 @@ run and wait for it **once**, for at most 5 minutes total. If it has not
 finished by then, record ❌ for that check and move on to the next
 requirement — do not keep waiting.
 
+Run the test requirements below **strictly in order**. Do not start step N+1
+until step N has completed and you have observed its exit code. Do not issue
+tool calls in parallel — dispatch one command, wait for it to finish, then
+dispatch the next. In particular, `./bin/threat-detect --version` depends on
+`make build` from the previous step and MUST NOT be launched before that build
+has returned.
+
 ## Test Requirements
 
 1. Use GitHub tools to read the latest 2 pull requests in `${{ github.repository }}` and record their numbers and titles only.


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01M0B2199HZHQT468KRCE5CVX6)

## What

Adds an explicit "strictly in order, no parallel tool calls" guard paragraph to all three standalone smoke prompts:

- `.github/workflows/smoke-codex-standalone.md`
- `.github/workflows/smoke-copilot-standalone.md`
- `.github/workflows/smoke-claude-standalone.md`

## Why

Fixes the false FAIL in [issue #883](https://github.com/github/gh-aw-threat-detection/issues/883) (Smoke Codex Standalone run [32166466281](https://github.com/github/gh-aw-threat-detection/actions/runs/32166466281)).

The workflow job itself succeeded — all steps of the `agent` job (`95807192530`) were green. The "FAIL" was reported by the Codex agent's own smoke summary because step 6 (`./bin/threat-detect --version`) exited 127 (`No such file or directory`).

Root cause, from the agent stdio transcript:

| order dispatched | command | exit |
|---|---|---|
| item_2 | `./bin/threat-detect --version` | **127** |
| item_1 | `gh pr list …` | 0 |
| item_3 | `curl -fsSL …` | 0 |
| item_4 | `make lint` | 0 |
| item_5 | **`make build`** | 0 |

Codex fired `--version` in parallel with the earlier steps, so it ran **before** `make build` produced `bin/threat-detect`. The build then succeeded, but the agent never re-ran the version check — it recorded the earlier exit-127 as ❌ and marked overall FAIL.

## Fix

A short paragraph placed just above `## Test Requirements` in each smoke prompt:

> Run the test requirements below **strictly in order**. Do not start step N+1 until step N has completed and you have observed its exit code. Do not issue tool calls in parallel — dispatch one command, wait for it to finish, then dispatch the next. In particular, `./bin/threat-detect --version` depends on `make build` from the previous step and MUST NOT be launched before that build has returned.

Applied to the copilot and claude smokes as well so the same class of nondeterminism can't bite them.

## Lock files

Not regenerated. The compiled locks pull the prompt body via `{{#runtime-import .github/workflows/<name>.md}}` at runtime, so prompt-body edits take effect on the next run without a recompile. Skipping the recompile also avoids clashing with the in-flight gh-aw v0.87.0 bump in PR #881 (the local compiler here is v0.87.0 while `main` is v0.81.6).

## Testing

- `.md` edits only; no code or Go changes.
- No workflow steps changed — only in-prompt instructions to the agent.
- Next scheduled run of each smoke will exercise the new instruction against the live agent.

Closes #883.