### PR TITLE
fix(engine): grant Read tool and acceptEdits permission mode to Claude

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -331,13 +331,28 @@ func copilotHarnessAwfConfigEnvAt(harnessDefaultPath string) []string {
 // or a --reason argument — the exact shell-expansion surface the file transport
 // exists to remove — so the tool grant and the prompt must stay in step.
 //
-// This grants no capability beyond Bash, which can already write files.
-var resultToolClaudeTools = []string{"Bash", "Write", "Edit"}
+// Read, Read(/tmp/*), and Read(/tmp/gh-aw/*) let the model load the artifact
+// files the prompt tells it to analyze (workflow prompt file, agent output,
+// patch/bundle, comment memory) directly, without falling back to `Bash cat`.
+// Those artifacts live under /tmp/gh-aw/threat-detection/, outside the
+// process's working directory, so plain "Read" alone is not always sufficient
+// under Claude's workingDir sandbox; the path-scoped grants cover that case.
+//
+// This grants no capability beyond Bash, which can already read and write files.
+var resultToolClaudeTools = []string{"Bash", "Write", "Edit", "Read", "Read(/tmp/*)", "Read(/tmp/gh-aw/*)"}
+
+// claudePermissionMode is passed via --permission-mode when the result-tool
+// grant is active. Claude Code defaults to interactive permission prompting,
+// which has no user to respond in a CI run and denies tool use (including
+// Read outside the working directory) after a few attempts. acceptEdits
+// makes --allowed-tools the effective boundary instead, matching gh-aw's own
+// Claude engine invocation (pkg/workflow/claude_engine.go).
+const claudePermissionMode = "acceptEdits"
 
 func claudeArgs(model string, allowResultTool bool) []string {
 	args := []string{"--print", "--verbose", "--output-format", "stream-json"}
 	if allowResultTool {
-		args = append(args, "--allowed-tools", strings.Join(resultToolClaudeTools, ","))
+		args = append(args, "--permission-mode", claudePermissionMode, "--allowed-tools", strings.Join(resultToolClaudeTools, ","))
 	}
 	if model != "" {
 		args = append(args, "--model", model)
@@ -352,7 +367,7 @@ func claudeArgs(model string, allowResultTool bool) []string {
 func claudeHarnessArgs(promptPath, model string, allowResultTool bool) []string {
 	args := []string{"--print", "--verbose", "--output-format", "stream-json"}
 	if allowResultTool {
-		args = append(args, "--allowed-tools", strings.Join(resultToolClaudeTools, ","))
+		args = append(args, "--permission-mode", claudePermissionMode, "--allowed-tools", strings.Join(resultToolClaudeTools, ","))
 	}
 	if model != "" {
 		args = append(args, "--model", model)

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -248,7 +248,7 @@ func TestEngineCommandArgs(t *testing.T) {
 
 	t.Run("claude with result-tool grant", func(t *testing.T) {
 		got := claudeArgs("claude-sonnet-4.6", true)
-		want := []string{"--print", "--verbose", "--output-format", "stream-json", "--allowed-tools", "Bash,Write,Edit", "--model", "claude-sonnet-4.6", "-"}
+		want := []string{"--print", "--verbose", "--output-format", "stream-json", "--permission-mode", "acceptEdits", "--allowed-tools", "Bash,Write,Edit,Read,Read(/tmp/*),Read(/tmp/gh-aw/*)", "--model", "claude-sonnet-4.6", "-"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("claudeArgs() = %#v, want %#v", got, want)
 		}
@@ -256,7 +256,7 @@ func TestEngineCommandArgs(t *testing.T) {
 
 	t.Run("claude harness args", func(t *testing.T) {
 		got := claudeHarnessArgs("/tmp/prompt.txt", "claude-sonnet-4.6", true)
-		want := []string{"--print", "--verbose", "--output-format", "stream-json", "--allowed-tools", "Bash,Write,Edit", "--model", "claude-sonnet-4.6", "--prompt-file", "/tmp/prompt.txt"}
+		want := []string{"--print", "--verbose", "--output-format", "stream-json", "--permission-mode", "acceptEdits", "--allowed-tools", "Bash,Write,Edit,Read,Read(/tmp/*),Read(/tmp/gh-aw/*)", "--model", "claude-sonnet-4.6", "--prompt-file", "/tmp/prompt.txt"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("claudeHarnessArgs() = %#v, want %#v", got, want)
 		}
@@ -279,7 +279,8 @@ func TestEngineCommandArgs(t *testing.T) {
 		wantArgs := []string{
 			harnessPath, "claude",
 			"--print", "--verbose", "--output-format", "stream-json",
-			"--allowed-tools", "Bash,Write,Edit",
+			"--permission-mode", "acceptEdits",
+			"--allowed-tools", "Bash,Write,Edit,Read,Read(/tmp/*),Read(/tmp/gh-aw/*)",
 			"--model", "claude-sonnet-4.6",
 			"--prompt-file", "/tmp/prompt.txt",
 		}


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01M0B86MXDAG4EP2GJSZFJD4GQ)

## Problem

`threat-detect --engine claude` spawns Claude with:

```
claude --print --verbose --output-format stream-json \
  --allowed-tools Bash,Write,Edit --model <model> -
```

Two issues:

1. **No `--permission-mode`** — Claude defaults to interactive permission mode, which requires user consent for tool use. There's no user in Actions.
2. **`Read` is not in `--allowed-tools`** — the prompt template instructs the model to "Read and analyze" the workflow prompt file, agent output, patch, and comment-memory files, but those artifacts live under `/tmp/gh-aw/threat-detection/`, outside Claude's working directory, so `Read` there is denied by the `workingDir` sandbox even if it were granted.

On Sonnet-class models this is masked because the model falls back to `Bash cat` when `Read` is denied. On Haiku (the default `detection` model alias resolved via `models.json`), the model exhausts its self-correction retries without ever calling `threat_detection_result`, producing `invalid_report_exhausted` and failing the downstream "Conclude threat detection" step with `ERR_PARSE: Detection result file not found`.

Reported against a real failure in `github/gh-aw`'s `daily-safe-outputs-conformance` workflow using `ANTHROPIC_MODEL: detection` (Haiku), which does not occur in this repo's own `smoke-claude-standalone` because it pins `claude-sonnet-5`.

## Fix

In `pkg/engine/engine.go` (`claudeArgs` / `claudeHarnessArgs`, gated on the existing result-tool grant):

- Add `--permission-mode acceptEdits`, matching `gh-aw`'s own Claude engine invocation (`pkg/workflow/claude_engine.go`), so `--allowed-tools` becomes the effective boundary instead of interactive prompting.
- Add `Read`, `Read(/tmp/*)`, and `Read(/tmp/gh-aw/*)` to the tool grant so the model can read the artifact files directly under their actual runtime path, without depending on a `Bash cat` fallback.

This grants no capability beyond what `Bash` already allows (reading and writing files via shell).

## Testing

- `make fmt lint build test test-scripts` all pass.
- `make security-scan` fails identically on `main` before this change (pre-existing `gosec` G104 findings unrelated to this diff) — confirmed via `git stash`.
- Updated `pkg/engine/engine_test.go` expectations for the new `--permission-mode` and `--allowed-tools` values across `claudeArgs`, `claudeHarnessArgs`, and the harness-command test.