### PR TITLE
feat(conclude): render "warnings : (none)" on clean runs

### DIFF
--- a/cmd/threat-detect/conclude.go
+++ b/cmd/threat-detect/conclude.go
@@ -392,7 +392,9 @@ func (c *concluder) reportVerdict(result *detector.Result, reasons []string) {
 // everything", not "a threat was found", so they are rendered separately from
 // both the verdict and the reasons — visible in the job log without a reader
 // having to consult the annotations. They never affect the verdict or the
-// exit code.
+// exit code. When there are no warnings, a "(none)" line is still emitted so
+// the warnings channel is always visible in the verdict block, mirroring the
+// reasons rendering.
 //
 // Each field is host-controlled or detector-composed (never model-authored),
 // but Message embeds host-controlled paths, so every value is sanitized before
@@ -400,6 +402,7 @@ func (c *concluder) reportVerdict(result *detector.Result, reasons []string) {
 // applies to its untrusted content.
 func (c *concluder) reportWarnings(warnings []detector.ResultWarning) {
 	if len(warnings) == 0 {
+		c.info("   warnings         : (none)")
 		return
 	}
 	c.info(fmt.Sprintf("⚠️  Detector warnings (%d) — artifact channels that could not be fully inspected. These do not affect the verdict.", len(warnings)))

--- a/cmd/threat-detect/conclude_warnings_test.go
+++ b/cmd/threat-detect/conclude_warnings_test.go
@@ -88,9 +88,9 @@ func TestConcludeWarningsSanitizedForControlChars(t *testing.T) {
 	}
 }
 
-// TestConcludeNoWarningsBlockWhenEmpty verifies the warnings section is
-// silent when there are no warnings — the log should not contain a stray
-// ⚠️ header for a clean run.
+// TestConcludeNoWarningsBlockWhenEmpty verifies the warnings section renders
+// a "(none)" line on a clean run — mirroring the reasons block — and does
+// not emit the ⚠️ header reserved for actual detector warnings.
 func TestConcludeNoWarningsBlockWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	resultFile := writeResultFixture(t, safeVerdict)
@@ -107,7 +107,11 @@ func TestConcludeNoWarningsBlockWhenEmpty(t *testing.T) {
 	if code := c.run(resultFile); code != concludeExitProceed {
 		t.Fatalf("run returned %d; log:\n%s", code, stdout.String())
 	}
-	if strings.Contains(stdout.String(), "Detector warnings") {
-		t.Errorf("no warnings header expected on a clean run; got:\n%s", stdout.String())
+	got := stdout.String()
+	if strings.Contains(got, "Detector warnings") {
+		t.Errorf("no ⚠️ warnings header expected on a clean run; got:\n%s", got)
+	}
+	if !strings.Contains(got, "warnings         : (none)") {
+		t.Errorf("expected 'warnings         : (none)' line on a clean run; got:\n%s", got)
 	}
 }


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01M1269VK5SD3F2Z9VZ4J0JGNX)

## Problem

In the smoke workflow's **Conclude Threat Detection** step, a clean run currently ends with:

```
📋 Threat detection verdict (from structured result file):
   prompt_injection : false
   secret_leak      : false
   malicious_patch  : false
   reasons          : (none)
✅ No security threats detected. Safe outputs may proceed.
```

The **warnings** channel is entirely absent from the block. Looking at the log (see the [linked smoke run](https://github.com/github/gh-aw-threat-detection/actions/runs/33100962523/job/98618976436)), there is no way to tell whether the detector reported zero warnings or whether the rendering was skipped for an unrelated reason. `reportWarnings` returned early when `len(warnings) == 0`.

## Fix

Emit an aligned `warnings         : (none)` line when the result carries no warnings, mirroring the existing `reasons          : (none)` line. The distinct `⚠️ Detector warnings (N)` header is still reserved for actual detector-authored warnings — that path is unchanged.

After this change a clean run reads:

```
   prompt_injection : false
   secret_leak      : false
   malicious_patch  : false
   reasons          : (none)
   warnings         : (none)
✅ No security threats detected. Safe outputs may proceed.
```

## Tests

- Updated `TestConcludeNoWarningsBlockWhenEmpty` to assert the `(none)` line is present while still asserting the ⚠️ header does **not** appear on a clean run.
- Existing `TestConcludeRendersWarningsWithMarker` still guards the header rendering on the warnings-present path.
- `make fmt lint` and `go test ./...` pass locally.