### PR TITLE
chore(smokes): pin smoke locks to threat-detect v0.5.1 prerelease

### DIFF
--- a/.github/workflows/smoke-claude-standalone.lock.yml
+++ b/.github/workflows/smoke-claude-standalone.lock.yml
@@ -1511,7 +1511,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.5.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.5.1
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'

--- a/.github/workflows/smoke-codex-standalone.lock.yml
+++ b/.github/workflows/smoke-codex-standalone.lock.yml
@@ -1522,7 +1522,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.5.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.5.1
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'

--- a/.github/workflows/smoke-copilot-standalone.lock.yml
+++ b/.github/workflows/smoke-copilot-standalone.lock.yml
@@ -1460,7 +1460,7 @@ jobs:
       - name: Install threat-detect binary
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.5.0
+          bash "${RUNNER_TEMP}/gh-aw/actions/install_threat_detect_binary.sh" v0.5.1
       - name: Execute threat detection with AWF
         id: detection_agentic_execution
         if: always() && steps.detection_guard.outputs.run_detection == 'true'


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01M126TBWE0GC4XY4XM7YB729X)

Points the three standalone smoke workflows at the unpromoted `threat-detect` **v0.5.1** prerelease (up from v0.5.0), using the smoke path documented in [`skills/update-workflow-versions/SKILL.md`](../blob/main/skills/update-workflow-versions/SKILL.md).

## Changes

Targeted post-compile edit of the `install_threat_detect_binary.sh` argument in:

- `.github/workflows/smoke-copilot-standalone.lock.yml`
- `.github/workflows/smoke-claude-standalone.lock.yml`
- `.github/workflows/smoke-codex-standalone.lock.yml`

Non-smoke locks (`detection-stats-daily`, `detection-failure-monitor`, `gh-aw-issue-digest`, `gh-aw-parity-monitor`) are intentionally left on the compiler-emitted `v0.4.12` — they are not the test bed for detector prereleases.

## Notes

- `constants.DefaultThreatDetectVersion` in `gh-aw` is unchanged; this pin is deliberately ephemeral and will be reverted by the next `gh aw compile`.
- No compiler bump: locks remain at `compiler_version` `v0.87.5`.
- Verify by dispatching the top-level **Smoke** workflow after merge.