### PR TITLE
test(conclude): stop workflow-command markers leaking as CI annotations

### DIFF
--- a/cmd/threat-detect/conclude_test.go
+++ b/cmd/threat-detect/conclude_test.go
@@ -598,10 +598,16 @@ func TestRunConcludeDefaultsDetectionLogPath(t *testing.T) {
 	t.Setenv("GITHUB_OUTPUT", outPath)
 	t.Setenv("GITHUB_ENV", envPath)
 
-	code := runConclude([]string{"--result-file", resultFile})
-	if code != concludeExitFail {
-		t.Fatalf("runConclude() = %d, want %d", code, concludeExitFail)
-	}
+	// Wrap in captureStdout so the ERR_PARSE workflow command runConclude
+	// emits on the missing-result-file path doesn't leak into `go test`'s
+	// real stdout, where the Actions runner would harvest it as a job
+	// annotation on this otherwise-passing test.
+	_ = captureStdout(t, func() {
+		code := runConclude([]string{"--result-file", resultFile})
+		if code != concludeExitFail {
+			t.Fatalf("runConclude() = %d, want %d", code, concludeExitFail)
+		}
+	})
 	outputs := parseKV(t, outPath)
 	if got := outputs["reason"]; got != "parse_error" {
 		t.Fatalf("reason = %q, want %q", got, "parse_error")
@@ -1413,9 +1419,14 @@ func TestRunConcludeFullResultFileOverride(t *testing.T) {
 	t.Setenv("GITHUB_OUTPUT", filepath.Join(dir, "out"))
 	t.Setenv("GITHUB_ENV", filepath.Join(dir, "env"))
 
-	if code := runConclude([]string{"--result-file", resultFile, "--full-result-file", elsewhere}); code != concludeExitFail {
-		t.Fatalf("runConclude() = %d, want %d", code, concludeExitFail)
-	}
+	// captureStdout keeps the ERR_VALIDATION workflow command emitted on the
+	// verdict mismatch out of `go test`'s real stdout, where the Actions
+	// runner would otherwise turn it into a job annotation.
+	_ = captureStdout(t, func() {
+		if code := runConclude([]string{"--result-file", resultFile, "--full-result-file", elsewhere}); code != concludeExitFail {
+			t.Fatalf("runConclude() = %d, want %d", code, concludeExitFail)
+		}
+	})
 
 	c := &concluder{fullResultFile: ""}
 	if got := c.fullResultPath(resultFile); got != detector.FullResultPath(resultFile) {


### PR DESCRIPTION
> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/sessions/01M126W0NJ7FNCK5J2EEXQ17NS)

## Problem

Release run [33102325533](https://github.com/github/gh-aw-threat-detection/actions/runs/33102325533) succeeded, but its `build-release-artifacts` job shows two spurious GitHub Actions annotations on the `Run tests` step:

- `ERR_VALIDATION: ❌ Security threats detected: prompt injection …`
- `ERR_PARSE: ❌ Detection result file not found at: /tmp/TestRunConcludeDefaults…/detection_result.json`

Both point at Go temp-dir paths, which gives away the source: they are real `::error::` workflow-command bytes emitted by `runConclude` during unit tests, streamed through `go test` into the runner log, and harvested by the Actions runner as annotations on the otherwise-passing job.

`runConclude` wires `stdout: os.Stdout` and calls `c.command("error", …)` on the parse-failure and verdict-mismatch paths. Two tests exercise those paths without redirecting `os.Stdout`:

- `TestRunConcludeDefaultsDetectionLogPath` — missing result file → `ERR_PARSE` marker
- `TestRunConcludeFullResultFileOverride` — split-verdict mismatch → `ERR_VALIDATION` marker

## Fix

Wrap both `runConclude` calls in the existing `captureStdout` helper, matching the pattern already used by `TestRunConcludeExplicitEmptyFullResultFileDisablesLookup`. The tests still assert on `code` and `$GITHUB_OUTPUT` as before; only the workflow-command bytes stop leaking.

## Validation

- `make fmt lint test` — green locally.
- Behavior under test unchanged (same exit codes, same `reason` in `$GITHUB_OUTPUT`).

## Notes

The underlying run was already `success` — this is purely annotation noise on the job UI, not a real CI failure. No product-code behavior changes.